### PR TITLE
add query field

### DIFF
--- a/wit/types.wit
+++ b/wit/types.wit
@@ -79,6 +79,7 @@ default interface types {
   drop-outgoing-request: func(request: outgoing-request)
   incoming-request-method: func(request: incoming-request) -> method
   incoming-request-path: func(request: incoming-request) -> string
+  incoming-request-query: func(request: incoming-request) -> string
   incoming-request-scheme: func(request: incoming-request) -> option<scheme>
   incoming-request-authority: func(request: incoming-request) -> string
   incoming-request-headers: func(request: incoming-request) -> headers
@@ -86,6 +87,7 @@ default interface types {
   new-outgoing-request: func(
     method: method,
     path: string,
+    query: string,
     scheme: option<scheme>,
     authority: string,
     headers: headers


### PR DESCRIPTION
It's missing, as pointed out in #10.

This PR brings back some earlier question I had when sketching the initial Wit which I might as well ask since we're in the area:
* Should the request constructor take a single `record` so that the fields are named instead of relying on, in most languages, nameless positional order.
* Should there also be an option to create/consume the {scheme,authority,path,query} fields via single URL?  It does make more URL parsing work for the host (although it seems likely that this code would already be present in the underlying library anyways), but it may factor it out of the guest and may save number-of-hostcalls.  If so, in the request constructor, is the best way to express this as a variant taking either the above record and URL as two cases?