### PR TITLE
Remove 'query', rename 'path' to 'path-with-query'

### DIFF
--- a/wit/types.wit
+++ b/wit/types.wit
@@ -78,18 +78,16 @@ default interface types {
   drop-incoming-request: func(request: incoming-request)
   drop-outgoing-request: func(request: outgoing-request)
   incoming-request-method: func(request: incoming-request) -> method
-  incoming-request-path: func(request: incoming-request) -> string
-  incoming-request-query: func(request: incoming-request) -> string
+  incoming-request-path-and-query: func(request: incoming-request) -> option<string>
   incoming-request-scheme: func(request: incoming-request) -> option<scheme>
-  incoming-request-authority: func(request: incoming-request) -> string
+  incoming-request-authority: func(request: incoming-request) -> option<string>
   incoming-request-headers: func(request: incoming-request) -> headers
   incoming-request-consume: func(request: incoming-request) -> result<incoming-stream>
   new-outgoing-request: func(
     method: method,
-    path: string,
-    query: string,
+    path-and-query: option<string>,
     scheme: option<scheme>,
-    authority: string,
+    authority: option<string>,
     headers: headers
   ) -> outgoing-request
   outgoing-request-write: func(request: outgoing-request) -> result<outgoing-stream>

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -78,14 +78,14 @@ default interface types {
   drop-incoming-request: func(request: incoming-request)
   drop-outgoing-request: func(request: outgoing-request)
   incoming-request-method: func(request: incoming-request) -> method
-  incoming-request-path-and-query: func(request: incoming-request) -> option<string>
+  incoming-request-path-with-query: func(request: incoming-request) -> option<string>
   incoming-request-scheme: func(request: incoming-request) -> option<scheme>
   incoming-request-authority: func(request: incoming-request) -> option<string>
   incoming-request-headers: func(request: incoming-request) -> headers
   incoming-request-consume: func(request: incoming-request) -> result<incoming-stream>
   new-outgoing-request: func(
     method: method,
-    path-and-query: option<string>,
+    path-with-query: option<string>,
     scheme: option<scheme>,
     authority: option<string>,
     headers: headers


### PR DESCRIPTION
As discussed in #11.  `path-and-query` is made optional as well.  `scheme` was already optional, but `authority` was not, so I made it optional too b/c I think the same rationale applies, but lmk if not.