### PR TITLE
fix: rename `streams` interface

### DIFF
--- a/wit/deps/io/streams.wit
+++ b/wit/deps/io/streams.wit
@@ -3,7 +3,7 @@
 ///
 /// In the future, the component model is expected to add built-in stream types;
 /// when it does, they are expected to subsume this API.
-default interface streams {
+default interface io-streams {
     use poll.poll.{pollable}
 
     /// An error type returned from a stream operation. Currently this


### PR DESCRIPTION
Unfortunately, naming the interface dependency `streams` causes a clash with `wasi_snapshot_preview1.wasm` `streams` causing a runtime panic in `wit-component`. While the fix for this issue clearly belongs upstream, rename the interface to allow users to utilize the `wasi-http` interface out-of-the-box already today.

Refs https://github.com/bytecodealliance/wasm-tools/issues/967

You can use https://github.com/rvolosatovs/wasi-http-guest-repro to reproduce the issue and https://github.com/rvolosatovs/wasi-http-guest-repro/commit/96facabe5d971a49e3276db9c5bd49ee007310d6 to see it fixed by making this change