### PR TITLE
fix: rename `types` to `http-types`

### DIFF
--- a/wit/incoming-handler.wit
+++ b/wit/incoming-handler.wit
@@ -7,7 +7,7 @@
 //   that takes a `request` parameter and returns a `response` result.
 //
 interface incoming-handler {
-  use types.{incoming-request, response-outparam}
+  use http-types.{incoming-request, response-outparam}
 
   // The `handle` function takes an outparam instead of returning its response
   // so that the component may stream its response while streaming any other

--- a/wit/outgoing-handler.wit
+++ b/wit/outgoing-handler.wit
@@ -6,7 +6,7 @@
 //   that takes a `request` parameter and returns a `response` result.
 //
 interface outgoing-handler {
-  use types.{outgoing-request, request-options, future-incoming-response}
+  use http-types.{outgoing-request, request-options, future-incoming-response}
 
   // The parameter and result types of the `handle` function allow the caller
   // to concurrently stream the bodies of the outgoing request and the incoming

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -1,7 +1,7 @@
-// The `wasi:http/types` interface is meant to be imported by components to
+// The `wasi:http/http-types` interface is meant to be imported by components to
 // define the HTTP resource types and operations used by the component's
 // imported and exported interfaces.
-interface types {
+interface http-types {
   use wasi:io/streams.{input-stream, output-stream}
   use wasi:poll/poll.{pollable}
   


### PR DESCRIPTION
This is done for compatiblity with Wasmtime 11 and the rest of Wasm tooling