### PR TITLE
fix: ensure comments set as documentation

### DIFF
--- a/proxy.md
+++ b/proxy.md
@@ -1,4 +1,8 @@
 <h1><a name="proxy">World proxy</a></h1>
+<p>The <code>wasi:http/proxy</code> world captures a widely-implementable intersection of
+hosts that includes HTTP forward and reverse proxies. Components targeting
+this world may concurrently stream in and out any number of incoming and
+outgoing HTTP requests.</p>
 <ul>
 <li>Imports:
 <ul>
@@ -166,7 +170,14 @@ reached.</p>
 <h4><a name="datetime"><code>type datetime</code></a></h4>
 <p><a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
 <p>
-#### <a name="timezone_display">`record timezone-display`</a>
+#### <a name="timezone">`type timezone`</a>
+`u32`
+<p>A timezone.
+<p>In timezones that recognize daylight saving time, also known as daylight
+time and summer time, the information returned from the functions varies
+over time to reflect these adjustments.</p>
+<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
+<h4><a name="timezone_display"><code>record timezone-display</code></a></h4>
 <p>Information useful for displaying the timezone of a specific <a href="#datetime"><code>datetime</code></a>.</p>
 <p>This information may vary within a single <a href="#timezone"><code>timezone</code></a> to reflect daylight
 saving time adjustments.</p>
@@ -198,13 +209,6 @@ representation of the UTC offset may be returned, such as <code>-04:00</code>.</
 should return false.</p>
 </li>
 </ul>
-<h4><a name="timezone"><code>type timezone</code></a></h4>
-<p><code>u32</code></p>
-<p>A timezone.
-<p>In timezones that recognize daylight saving time, also known as daylight
-time and summer time, the information returned from the functions varies
-over time to reflect these adjustments.</p>
-<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
 <hr />
 <h3>Functions</h3>
 <h4><a name="display"><code>display: func</code></a></h4>
@@ -284,7 +288,11 @@ when it does, they are expected to subsume this API.</p>
 <h4><a name="pollable"><code>type pollable</code></a></h4>
 <p><a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></p>
 <p>
-#### <a name="stream_status">`enum stream-status`</a>
+#### <a name="stream_error">`record stream-error`</a>
+<p>An error type returned from a stream operation. Currently this
+doesn't provide any additional information.</p>
+<h5>Record Fields</h5>
+<h4><a name="stream_status"><code>enum stream-status</code></a></h4>
 <p>Streams provide a sequence of data and then end; once they end, they
 no longer provide any further data.</p>
 <p>For example, a stream reading from a file ends when the stream reaches
@@ -301,25 +309,6 @@ socket ends when the socket is closed.</p>
 <p>The stream has ended and will not produce any further data.
 </li>
 </ul>
-<h4><a name="stream_error"><code>record stream-error</code></a></h4>
-<p>An error type returned from a stream operation. Currently this
-doesn't provide any additional information.</p>
-<h5>Record Fields</h5>
-<h4><a name="output_stream"><code>type output-stream</code></a></h4>
-<p><code>u32</code></p>
-<p>An output bytestream. In the future, this will be replaced by handle
-types.
-<p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
-scaffolding until component-model's async features are ready.</p>
-<p><a href="#output_stream"><code>output-stream</code></a>s are <em>non-blocking</em> to the extent practical on
-underlying platforms. Except where specified otherwise, I/O operations also
-always return promptly, after the number of bytes that can be written
-promptly, which could even be zero. To wait for the stream to be ready to
-accept data, the <a href="#subscribe_to_output_stream"><code>subscribe-to-output-stream</code></a> function to obtain a
-<a href="#pollable"><code>pollable</code></a> which can be polled for using <code>wasi_poll</code>.</p>
-<p>And at present, it is a <code>u32</code> instead of being an actual handle, until
-the wit-bindgen implementation of handles and resources is ready.</p>
-<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
 <h4><a name="input_stream"><code>type input-stream</code></a></h4>
 <p><code>u32</code></p>
 <p>An input bytestream. In the future, this will be replaced by handle
@@ -332,6 +321,21 @@ promptly available than requested, they return the number of bytes promptly
 available, which could even be zero. To wait for data to be available,
 use the <a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a> function to obtain a <a href="#pollable"><code>pollable</code></a> which
 can be polled for using <code>wasi_poll</code>.</p>
+<p>And at present, it is a <code>u32</code> instead of being an actual handle, until
+the wit-bindgen implementation of handles and resources is ready.</p>
+<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
+<h4><a name="output_stream"><code>type output-stream</code></a></h4>
+<p><code>u32</code></p>
+<p>An output bytestream. In the future, this will be replaced by handle
+types.
+<p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
+scaffolding until component-model's async features are ready.</p>
+<p><a href="#output_stream"><code>output-stream</code></a>s are <em>non-blocking</em> to the extent practical on
+underlying platforms. Except where specified otherwise, I/O operations also
+always return promptly, after the number of bytes that can be written
+promptly, which could even be zero. To wait for the stream to be ready to
+accept data, the <a href="#subscribe_to_output_stream"><code>subscribe-to-output-stream</code></a> function to obtain a
+<a href="#pollable"><code>pollable</code></a> which can be polled for using <code>wasi_poll</code>.</p>
 <p>And at present, it is a <code>u32</code> instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.</p>
 <p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
@@ -583,6 +587,9 @@ be used.</p>
 <li><a name="get_stdin.0"></a> <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
 </ul>
 <h2><a name="wasi:http_types">Import interface wasi:http/types</a></h2>
+<p>The <a href="#wasi:http_types"><code>wasi:http/types</code></a> interface is meant to be imported by components to
+define the HTTP resource types and operations used by the component's
+imported and exported interfaces.</p>
 <hr />
 <h3>Types</h3>
 <h4><a name="input_stream"><code>type input-stream</code></a></h4>
@@ -594,36 +601,8 @@ be used.</p>
 #### <a name="pollable">`type pollable`</a>
 [`pollable`](#pollable)
 <p>
-#### <a name="status_code">`type status-code`</a>
-`u16`
-<p>
-#### <a name="scheme">`variant scheme`</a>
-<h5>Variant Cases</h5>
-<ul>
-<li><a name="scheme.http"><code>HTTP</code></a></li>
-<li><a name="scheme.https"><code>HTTPS</code></a></li>
-<li><a name="scheme.other"><code>other</code></a>: <code>string</code></li>
-</ul>
-<h4><a name="response_outparam"><code>type response-outparam</code></a></h4>
-<p><code>u32</code></p>
-<p>
-#### <a name="request_options">`record request-options`</a>
-<h5>Record Fields</h5>
-<ul>
-<li><a name="request_options.connect_timeout_ms"><code>connect-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</li>
-<li><a name="request_options.first_byte_timeout_ms"><code>first-byte-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</li>
-<li><a name="request_options.between_bytes_timeout_ms"><code>between-bytes-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</li>
-</ul>
-<h4><a name="outgoing_stream"><code>type outgoing-stream</code></a></h4>
-<p><a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></p>
-<p>
-#### <a name="outgoing_response">`type outgoing-response`</a>
-`u32`
-<p>
-#### <a name="outgoing_request">`type outgoing-request`</a>
-`u32`
-<p>
 #### <a name="method">`variant method`</a>
+<p>This type corresponds to HTTP standard Methods.</p>
 <h5>Variant Cases</h5>
 <ul>
 <li><a name="method.get"><code>get</code></a></li>
@@ -637,34 +616,18 @@ be used.</p>
 <li><a name="method.patch"><code>patch</code></a></li>
 <li><a name="method.other"><code>other</code></a>: <code>string</code></li>
 </ul>
-<h4><a name="incoming_stream"><code>type incoming-stream</code></a></h4>
-<p><a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></p>
-<p>
-#### <a name="incoming_response">`type incoming-response`</a>
-`u32`
-<p>
-#### <a name="incoming_request">`type incoming-request`</a>
-`u32`
-<p>
-#### <a name="future_write_trailers_result">`type future-write-trailers-result`</a>
-`u32`
-<p>
-#### <a name="future_trailers">`type future-trailers`</a>
-`u32`
-<p>
-#### <a name="future_incoming_response">`type future-incoming-response`</a>
-`u32`
-<p>
-#### <a name="fields">`type fields`</a>
-`u32`
-<p>
-#### <a name="trailers">`type trailers`</a>
-[`fields`](#fields)
-<p>
-#### <a name="headers">`type headers`</a>
-[`fields`](#fields)
-<p>
-#### <a name="error">`variant error`</a>
+<h4><a name="scheme"><code>variant scheme</code></a></h4>
+<p>This type corresponds to HTTP standard Related Schemes.</p>
+<h5>Variant Cases</h5>
+<ul>
+<li><a name="scheme.http"><code>HTTP</code></a></li>
+<li><a name="scheme.https"><code>HTTPS</code></a></li>
+<li><a name="scheme.other"><code>other</code></a>: <code>string</code></li>
+</ul>
+<h4><a name="error"><code>variant error</code></a></h4>
+<p>TODO: perhaps better align with HTTP semantics?
+This type enumerates the different kinds of errors that may occur when
+initially returning a response.</p>
 <h5>Variant Cases</h5>
 <ul>
 <li><a name="error.invalid_url"><code>invalid-url</code></a>: <code>string</code></li>
@@ -672,6 +635,120 @@ be used.</p>
 <li><a name="error.protocol_error"><code>protocol-error</code></a>: <code>string</code></li>
 <li><a name="error.unexpected_error"><code>unexpected-error</code></a>: <code>string</code></li>
 </ul>
+<h4><a name="fields"><code>type fields</code></a></h4>
+<p><code>u32</code></p>
+<p>This following block defines the `fields` resource which corresponds to
+HTTP standard Fields. Soon, when resource types are added, the `type
+fields = u32` type alias can be replaced by a proper `resource fields`
+definition containing all the functions using the method syntactic sugar.
+<h4><a name="headers"><code>type headers</code></a></h4>
+<p><a href="#fields"><a href="#fields"><code>fields</code></a></a></p>
+<p>
+#### <a name="trailers">`type trailers`</a>
+[`fields`](#fields)
+<p>
+#### <a name="incoming_stream">`type incoming-stream`</a>
+[`input-stream`](#input_stream)
+<p>The following block defines stream types which corresponds to the HTTP
+standard Contents and Trailers. With Preview3, all of these fields can be
+replaced by a stream<u8, option<trailers>>. In the interim, we need to
+build on separate resource types defined by `wasi:io/streams`. The
+`finish-` functions emulate the stream's result value and MUST be called
+exactly once after the final read/write from/to the stream before dropping
+the stream. The optional `future-` types describe the asynchronous result of
+reading/writing the optional HTTP trailers and MUST be waited on and dropped
+to complete streaming the request/response.
+<h4><a name="outgoing_stream"><code>type outgoing-stream</code></a></h4>
+<p><a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></p>
+<p>
+#### <a name="future_trailers">`type future-trailers`</a>
+`u32`
+<p>The following block defines the `future-trailers` resource, which is
+returned when finishing an `incoming-stream` to asychronously produce the
+final trailers.
+<h4><a name="future_write_trailers_result"><code>type future-write-trailers-result</code></a></h4>
+<p><code>u32</code></p>
+<p>The following block defines the `future-write-trailers-result` resource,
+which is returned when finishing an `outgoing-stream` and asychronously
+indicates the success or failure of writing the trailers.
+<h4><a name="incoming_request"><code>type incoming-request</code></a></h4>
+<p><code>u32</code></p>
+<p>The following block defines the `incoming-request` and `outgoing-request`
+resource types that correspond to HTTP standard Requests. Soon, when
+resource types are added, the `u32` type aliases can be replaced by proper
+`resource` type definitions containing all the functions as methods.
+Later, Preview2 will allow both types to be merged together into a single
+`request` type (that uses the single `stream` type mentioned above). The
+`consume` and `write` methods may only be called once (and return failure
+thereafter). The `headers` and `trailers` passed into and out of requests
+are shared with the request, with all mutations visible to all uses.
+Components MUST avoid updating `headers` and `trailers` after passing a
+request that points to them to the outside world.
+The streams returned by `consume` and `write` are owned by the request and
+response objects. The streams are destroyed when the request/response is
+dropped, thus a client MUST drop any handle referring to a request/response stream
+before dropping the request/response or passing ownership of the request/response
+to the outside world. The caller can also call drop on the stream before the
+request/response is dropped if they want to release resources earlier.
+<h4><a name="outgoing_request"><code>type outgoing-request</code></a></h4>
+<p><code>u32</code></p>
+<p>
+#### <a name="request_options">`record request-options`</a>
+<p>Additional optional parameters that can be set when making a request.</p>
+<h5>Record Fields</h5>
+<ul>
+<li>
+<p><a name="request_options.connect_timeout_ms"><code>connect-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</p>
+<p>The following timeouts are specific to the HTTP protocol and work
+independently of the overall timeouts passed to `io.poll.poll-oneoff`.
+The timeout for the initial connect.
+</li>
+<li>
+<p><a name="request_options.first_byte_timeout_ms"><code>first-byte-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</p>
+<p>The timeout for receiving the first byte of the response body.
+</li>
+<li>
+<p><a name="request_options.between_bytes_timeout_ms"><code>between-bytes-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</p>
+<p>The timeout for receiving the next chunk of bytes in the response body
+stream.
+</li>
+</ul>
+<h4><a name="response_outparam"><code>type response-outparam</code></a></h4>
+<p><code>u32</code></p>
+<p>The following block defines a special resource type used by the
+`wasi:http/incoming-handler` interface. When resource types are added, this
+block can be replaced by a proper `resource response-outparam { ... }`
+definition. Later, with Preview3, the need for an outparam goes away entirely
+(the `wasi:http/handler` interface used for both incoming and outgoing can
+simply return a `stream`).
+<h4><a name="status_code"><code>type status-code</code></a></h4>
+<p><code>u16</code></p>
+<p>This type corresponds to the HTTP standard Status Code.
+<h4><a name="incoming_response"><code>type incoming-response</code></a></h4>
+<p><code>u32</code></p>
+<p>The following block defines the `incoming-response` and `outgoing-response`
+resource types that correspond to HTTP standard Responses. Soon, when
+resource types are added, the `u32` type aliases can be replaced by proper
+`resource` type definitions containing all the functions as methods. Later,
+Preview2 will allow both types to be merged together into a single `response`
+type (that uses the single `stream` type mentioned above). The `consume` and
+`write` methods may only be called once (and return failure thereafter).
+The `headers` and `trailers` passed into and out of responses are shared
+with the response, with all mutations visible to all uses. Components MUST
+avoid updating `headers` and `trailers` after passing a response that
+points to them to the outside world.
+<h4><a name="outgoing_response"><code>type outgoing-response</code></a></h4>
+<p><code>u32</code></p>
+<p>
+#### <a name="future_incoming_response">`type future-incoming-response`</a>
+`u32`
+<p>The following block defines a special resource type used by the
+`wasi:http/outgoing-handler` interface to emulate
+`future<result<response, error>>` in advance of Preview3. Given a
+`future-incoming-response`, the client can call the non-blocking `get`
+method to get the result if it is available. If the result is not available,
+the client can call `listen` to get a `pollable` that can be passed to
+`io.poll.poll-oneoff`.
 <hr />
 <h3>Functions</h3>
 <h4><a name="drop_fields"><code>drop-fields: func</code></a></h4>
@@ -987,6 +1064,11 @@ be used.</p>
 <li><a name="listen_to_future_incoming_response.0"></a> <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
 </ul>
 <h2><a name="wasi:http_outgoing_handler">Import interface wasi:http/outgoing-handler</a></h2>
+<p>The <a href="#wasi:http_outgoing_handler"><code>wasi:http/outgoing-handler</code></a> interface is meant to be imported by
+components and implemented by the host.</p>
+<p>NOTE: in Preview3, this interface will be merged with
+<a href="#wasi:http_outgoing_handler"><code>wasi:http/outgoing-handler</code></a> into a single <code>wasi:http/handler</code> interface
+that takes a <code>request</code> parameter and returns a <code>response</code> result.</p>
 <hr />
 <h3>Types</h3>
 <h4><a name="outgoing_request"><code>type outgoing-request</code></a></h4>
@@ -1001,6 +1083,9 @@ be used.</p>
 ----
 <h3>Functions</h3>
 <h4><a name="handle"><code>handle: func</code></a></h4>
+<p>The parameter and result types of the <a href="#handle"><code>handle</code></a> function allow the caller
+to concurrently stream the bodies of the outgoing request and the incoming
+response.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="handle.request"><code>request</code></a>: <a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a></li>
@@ -1022,6 +1107,16 @@ be used.</p>
 ----
 <h3>Functions</h3>
 <h4><a name="handle"><code>handle: func</code></a></h4>
+<p>The <a href="#handle"><code>handle</code></a> function takes an outparam instead of returning its response
+so that the component may stream its response while streaming any other
+request or response bodies. The callee MUST write a response to the
+<code>response-out</code> and then finish the response before returning. The caller
+is expected to start streaming the response once <a href="#set_response_outparam"><code>set-response-outparam</code></a>
+is called and finish streaming the response when <a href="#drop_response_outparam"><code>drop-response-outparam</code></a>
+is called. The <a href="#handle"><code>handle</code></a> function is then allowed to continue executing
+any post-response logic before returning. While this post-response
+execution is taken off the critical path, since there is no return value,
+there is no way to report its success or failure.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="handle.request"><code>request</code></a>: <a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a></li>

--- a/wit/handler.wit
+++ b/wit/handler.wit
@@ -1,43 +1,43 @@
-// The `wasi:http/incoming-handler` interface is meant to be exported by
-// components and called by the host in response to a new incoming HTTP
-// response.
-//
-//   NOTE: in Preview3, this interface will be merged with
-//   `wasi:http/outgoing-handler` into a single `wasi:http/handler` interface
-//   that takes a `request` parameter and returns a `response` result.
-//
+/// The `wasi:http/incoming-handler` interface is meant to be exported by
+/// components and called by the host in response to a new incoming HTTP
+/// response.
+///
+///   NOTE: in Preview3, this interface will be merged with
+///   `wasi:http/outgoing-handler` into a single `wasi:http/handler` interface
+///   that takes a `request` parameter and returns a `response` result.
+///
 interface incoming-handler {
   use types.{incoming-request, response-outparam}
 
-  // The `handle` function takes an outparam instead of returning its response
-  // so that the component may stream its response while streaming any other
-  // request or response bodies. The callee MUST write a response to the
-  // `response-out` and then finish the response before returning. The caller
-  // is expected to start streaming the response once `set-response-outparam`
-  // is called and finish streaming the response when `drop-response-outparam`
-  // is called. The `handle` function is then allowed to continue executing
-  // any post-response logic before returning. While this post-response
-  // execution is taken off the critical path, since there is no return value,
-  // there is no way to report its success or failure.
+  /// The `handle` function takes an outparam instead of returning its response
+  /// so that the component may stream its response while streaming any other
+  /// request or response bodies. The callee MUST write a response to the
+  /// `response-out` and then finish the response before returning. The caller
+  /// is expected to start streaming the response once `set-response-outparam`
+  /// is called and finish streaming the response when `drop-response-outparam`
+  /// is called. The `handle` function is then allowed to continue executing
+  /// any post-response logic before returning. While this post-response
+  /// execution is taken off the critical path, since there is no return value,
+  /// there is no way to report its success or failure.
   handle: func(
     request: incoming-request,
     response-out: response-outparam
   )
 }
 
-// The `wasi:http/outgoing-handler` interface is meant to be imported by
-// components and implemented by the host.
-//
-//   NOTE: in Preview3, this interface will be merged with
-//   `wasi:http/outgoing-handler` into a single `wasi:http/handler` interface
-//   that takes a `request` parameter and returns a `response` result.
-//
+/// The `wasi:http/outgoing-handler` interface is meant to be imported by
+/// components and implemented by the host.
+///
+///   NOTE: in Preview3, this interface will be merged with
+///   `wasi:http/outgoing-handler` into a single `wasi:http/handler` interface
+///   that takes a `request` parameter and returns a `response` result.
+///
 interface outgoing-handler {
   use types.{outgoing-request, request-options, future-incoming-response}
 
-  // The parameter and result types of the `handle` function allow the caller
-  // to concurrently stream the bodies of the outgoing request and the incoming
-  // response.
+  /// The parameter and result types of the `handle` function allow the caller
+  /// to concurrently stream the bodies of the outgoing request and the incoming
+  /// response.
   handle: func(
     request: outgoing-request,
     options: option<request-options>

--- a/wit/proxy.wit
+++ b/wit/proxy.wit
@@ -1,34 +1,34 @@
 package wasi:http
 
-// The `wasi:http/proxy` world captures a widely-implementable intersection of
-// hosts that includes HTTP forward and reverse proxies. Components targeting
-// this world may concurrently stream in and out any number of incoming and
-// outgoing HTTP requests.
+/// The `wasi:http/proxy` world captures a widely-implementable intersection of
+/// hosts that includes HTTP forward and reverse proxies. Components targeting
+/// this world may concurrently stream in and out any number of incoming and
+/// outgoing HTTP requests.
 world proxy {
-  // HTTP proxies have access to time and randomness.
+  /// HTTP proxies have access to time and randomness.
   import wasi:clocks/wall-clock
   import wasi:clocks/monotonic-clock
   import wasi:clocks/timezone
   import wasi:random/random
 
-  // Proxies have standard output and error streams which are expected to
-  // terminate in a developer-facing console provided by the host.
+  /// Proxies have standard output and error streams which are expected to
+  /// terminate in a developer-facing console provided by the host.
   import wasi:cli/stdout
   import wasi:cli/stderr
 
-  // TODO: this is a temporary workaround until component tooling is able to
-  // gracefully handle the absence of stdin. Hosts must return an eof stream
-  // for this import, which is what wasi-libc + tooling will do automatically
-  // when this import is properly removed.
+  /// TODO: this is a temporary workaround until component tooling is able to
+  /// gracefully handle the absence of stdin. Hosts must return an eof stream
+  /// for this import, which is what wasi-libc + tooling will do automatically
+  /// when this import is properly removed.
   import wasi:cli/stdin
 
-  // This is the default handler to use when user code simply wants to make an
-  // HTTP request (e.g., via `fetch()`).
+  /// This is the default handler to use when user code simply wants to make an
+  /// HTTP request (e.g., via `fetch()`).
   import outgoing-handler
 
-  // The host delivers incoming HTTP requests to a component by calling the
-  // `handle` function of this exported interface. A host may arbitrarily reuse
-  // or not reuse component instance when delivering incoming HTTP requests and
-  // thus a component must be able to handle 0..N calls to `handle`.
+  /// The host delivers incoming HTTP requests to a component by calling the
+  /// `handle` function of this exported interface. A host may arbitrarily reuse
+  /// or not reuse component instance when delivering incoming HTTP requests and
+  /// thus a component must be able to handle 0..N calls to `handle`.
   export incoming-handler
 }

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -1,11 +1,11 @@
-// The `wasi:http/types` interface is meant to be imported by components to
-// define the HTTP resource types and operations used by the component's
-// imported and exported interfaces.
+/// The `wasi:http/types` interface is meant to be imported by components to
+/// define the HTTP resource types and operations used by the component's
+/// imported and exported interfaces.
 interface types {
   use wasi:io/streams.{input-stream, output-stream}
   use wasi:poll/poll.{pollable}
   
-  // This type corresponds to HTTP standard Methods.
+  /// This type corresponds to HTTP standard Methods.
   variant method {
     get,
     head,
@@ -19,16 +19,16 @@ interface types {
     other(string)
   }
 
-  // This type corresponds to HTTP standard Related Schemes.
+  /// This type corresponds to HTTP standard Related Schemes.
   variant scheme {
     HTTP,
     HTTPS,
     other(string)
   }
 
-  // TODO: perhaps better align with HTTP semantics?
-  // This type enumerates the different kinds of errors that may occur when
-  // initially returning a response.
+  /// TODO: perhaps better align with HTTP semantics?
+  /// This type enumerates the different kinds of errors that may occur when
+  /// initially returning a response.
   variant error {
       invalid-url(string),
       timeout-error(string),
@@ -36,10 +36,10 @@ interface types {
       unexpected-error(string)
   }
 
-  // This following block defines the `fields` resource which corresponds to
-  // HTTP standard Fields. Soon, when resource types are added, the `type
-  // fields = u32` type alias can be replaced by a proper `resource fields`
-  // definition containing all the functions using the method syntactic sugar.
+  /// This following block defines the `fields` resource which corresponds to
+  /// HTTP standard Fields. Soon, when resource types are added, the `type
+  /// fields = u32` type alias can be replaced by a proper `resource fields`
+  /// definition containing all the functions using the method syntactic sugar.
   type fields = u32
   drop-fields: func(fields: fields)
   new-fields: func(entries: list<tuple<string,list<u8>>>) -> fields
@@ -53,54 +53,54 @@ interface types {
   type headers = fields
   type trailers = fields
 
-  // The following block defines stream types which corresponds to the HTTP
-  // standard Contents and Trailers. With Preview3, all of these fields can be
-  // replaced by a stream<u8, option<trailers>>. In the interim, we need to
-  // build on separate resource types defined by `wasi:io/streams`. The
-  // `finish-` functions emulate the stream's result value and MUST be called
-  // exactly once after the final read/write from/to the stream before dropping
-  // the stream. The optional `future-` types describe the asynchronous result of
-  // reading/writing the optional HTTP trailers and MUST be waited on and dropped
-  // to complete streaming the request/response.
+  /// The following block defines stream types which corresponds to the HTTP
+  /// standard Contents and Trailers. With Preview3, all of these fields can be
+  /// replaced by a stream<u8, option<trailers>>. In the interim, we need to
+  /// build on separate resource types defined by `wasi:io/streams`. The
+  /// `finish-` functions emulate the stream's result value and MUST be called
+  /// exactly once after the final read/write from/to the stream before dropping
+  /// the stream. The optional `future-` types describe the asynchronous result of
+  /// reading/writing the optional HTTP trailers and MUST be waited on and dropped
+  /// to complete streaming the request/response.
   type incoming-stream = input-stream
   type outgoing-stream = output-stream
   finish-incoming-stream: func(s: incoming-stream) -> option<future-trailers>
   finish-outgoing-stream: func(s: outgoing-stream)
   finish-outgoing-stream-with-trailers: func(s: outgoing-stream, trailers: trailers) -> future-write-trailers-result
 
-  // The following block defines the `future-trailers` resource, which is
-  // returned when finishing an `incoming-stream` to asychronously produce the
-  // final trailers.
+  /// The following block defines the `future-trailers` resource, which is
+  /// returned when finishing an `incoming-stream` to asychronously produce the
+  /// final trailers.
   type future-trailers = u32
   drop-future-trailers: func(f: future-trailers)
   future-trailers-get: func(f: future-trailers) -> option<result<trailers, error>>
   listen-to-future-trailers: func(f: future-trailers) -> pollable
 
-  // The following block defines the `future-write-trailers-result` resource,
-  // which is returned when finishing an `outgoing-stream` and asychronously
-  // indicates the success or failure of writing the trailers.
+  /// The following block defines the `future-write-trailers-result` resource,
+  /// which is returned when finishing an `outgoing-stream` and asychronously
+  /// indicates the success or failure of writing the trailers.
   type future-write-trailers-result = u32
   drop-future-write-trailers-result: func(f: future-write-trailers-result)
   future-write-trailers-result-get: func(f: future-write-trailers-result) -> option<result<_, error>>
   listen-to-future-write-trailers-result: func(f: future-write-trailers-result) -> pollable
 
-  // The following block defines the `incoming-request` and `outgoing-request`
-  // resource types that correspond to HTTP standard Requests. Soon, when
-  // resource types are added, the `u32` type aliases can be replaced by proper
-  // `resource` type definitions containing all the functions as methods.
-  // Later, Preview2 will allow both types to be merged together into a single
-  // `request` type (that uses the single `stream` type mentioned above). The
-  // `consume` and `write` methods may only be called once (and return failure
-  // thereafter). The `headers` and `trailers` passed into and out of requests
-  // are shared with the request, with all mutations visible to all uses.
-  // Components MUST avoid updating `headers` and `trailers` after passing a
-  // request that points to them to the outside world.
-  // The streams returned by `consume` and `write` are owned by the request and
-  // response objects. The streams are destroyed when the request/response is
-  // dropped, thus a client MUST drop any handle referring to a request/response stream
-  // before dropping the request/response or passing ownership of the request/response
-  // to the outside world. The caller can also call drop on the stream before the 
-  // request/response is dropped if they want to release resources earlier.
+  /// The following block defines the `incoming-request` and `outgoing-request`
+  /// resource types that correspond to HTTP standard Requests. Soon, when
+  /// resource types are added, the `u32` type aliases can be replaced by proper
+  /// `resource` type definitions containing all the functions as methods.
+  /// Later, Preview2 will allow both types to be merged together into a single
+  /// `request` type (that uses the single `stream` type mentioned above). The
+  /// `consume` and `write` methods may only be called once (and return failure
+  /// thereafter). The `headers` and `trailers` passed into and out of requests
+  /// are shared with the request, with all mutations visible to all uses.
+  /// Components MUST avoid updating `headers` and `trailers` after passing a
+  /// request that points to them to the outside world.
+  /// The streams returned by `consume` and `write` are owned by the request and
+  /// response objects. The streams are destroyed when the request/response is
+  /// dropped, thus a client MUST drop any handle referring to a request/response stream
+  /// before dropping the request/response or passing ownership of the request/response
+  /// to the outside world. The caller can also call drop on the stream before the 
+  /// request/response is dropped if they want to release resources earlier.
   type incoming-request = u32
   type outgoing-request = u32
   drop-incoming-request: func(request: incoming-request)
@@ -120,46 +120,46 @@ interface types {
   ) -> result<outgoing-request, error>
   outgoing-request-write: func(request: outgoing-request) -> result<outgoing-stream>
 
-  // Additional optional parameters that can be set when making a request.
+  /// Additional optional parameters that can be set when making a request.
   record request-options {
-    // The following timeouts are specific to the HTTP protocol and work
-    // independently of the overall timeouts passed to `io.poll.poll-oneoff`.
+    /// The following timeouts are specific to the HTTP protocol and work
+    /// independently of the overall timeouts passed to `io.poll.poll-oneoff`.
 
-    // The timeout for the initial connect.
+    /// The timeout for the initial connect.
     connect-timeout-ms: option<u32>,
 
-    // The timeout for receiving the first byte of the response body.
+    /// The timeout for receiving the first byte of the response body.
     first-byte-timeout-ms: option<u32>,
 
-    // The timeout for receiving the next chunk of bytes in the response body
-    // stream.
+    /// The timeout for receiving the next chunk of bytes in the response body
+    /// stream.
     between-bytes-timeout-ms: option<u32>
   }
 
-  // The following block defines a special resource type used by the
-  // `wasi:http/incoming-handler` interface. When resource types are added, this
-  // block can be replaced by a proper `resource response-outparam { ... }`
-  // definition. Later, with Preview3, the need for an outparam goes away entirely
-  // (the `wasi:http/handler` interface used for both incoming and outgoing can
-  // simply return a `stream`).
+  /// The following block defines a special resource type used by the
+  /// `wasi:http/incoming-handler` interface. When resource types are added, this
+  /// block can be replaced by a proper `resource response-outparam { ... }`
+  /// definition. Later, with Preview3, the need for an outparam goes away entirely
+  /// (the `wasi:http/handler` interface used for both incoming and outgoing can
+  /// simply return a `stream`).
   type response-outparam = u32
   drop-response-outparam: func(response: response-outparam)
   set-response-outparam: func(param: response-outparam, response: result<outgoing-response, error>) -> result
 
-  // This type corresponds to the HTTP standard Status Code.
+  /// This type corresponds to the HTTP standard Status Code.
   type status-code = u16
 
-  // The following block defines the `incoming-response` and `outgoing-response`
-  // resource types that correspond to HTTP standard Responses. Soon, when
-  // resource types are added, the `u32` type aliases can be replaced by proper
-  // `resource` type definitions containing all the functions as methods. Later,
-  // Preview2 will allow both types to be merged together into a single `response`
-  // type (that uses the single `stream` type mentioned above). The `consume` and
-  // `write` methods may only be called once (and return failure thereafter).
-  // The `headers` and `trailers` passed into and out of responses are shared
-  // with the response, with all mutations visible to all uses. Components MUST
-  // avoid updating `headers` and `trailers` after passing a response that
-  // points to them to the outside world.
+  /// The following block defines the `incoming-response` and `outgoing-response`
+  /// resource types that correspond to HTTP standard Responses. Soon, when
+  /// resource types are added, the `u32` type aliases can be replaced by proper
+  /// `resource` type definitions containing all the functions as methods. Later,
+  /// Preview2 will allow both types to be merged together into a single `response`
+  /// type (that uses the single `stream` type mentioned above). The `consume` and
+  /// `write` methods may only be called once (and return failure thereafter).
+  /// The `headers` and `trailers` passed into and out of responses are shared
+  /// with the response, with all mutations visible to all uses. Components MUST
+  /// avoid updating `headers` and `trailers` after passing a response that
+  /// points to them to the outside world.
   type incoming-response = u32
   type outgoing-response = u32
   drop-incoming-response: func(response: incoming-response)
@@ -173,13 +173,13 @@ interface types {
   ) -> result<outgoing-response, error>
   outgoing-response-write: func(response: outgoing-response) -> result<outgoing-stream>
 
-  // The following block defines a special resource type used by the
-  // `wasi:http/outgoing-handler` interface to emulate
-  // `future<result<response, error>>` in advance of Preview3. Given a
-  // `future-incoming-response`, the client can call the non-blocking `get`
-  // method to get the result if it is available. If the result is not available,
-  // the client can call `listen` to get a `pollable` that can be passed to
-  // `io.poll.poll-oneoff`.
+  /// The following block defines a special resource type used by the
+  /// `wasi:http/outgoing-handler` interface to emulate
+  /// `future<result<response, error>>` in advance of Preview3. Given a
+  /// `future-incoming-response`, the client can call the non-blocking `get`
+  /// method to get the result if it is available. If the result is not available,
+  /// the client can call `listen` to get a `pollable` that can be passed to
+  /// `io.poll.poll-oneoff`.
   type future-incoming-response = u32
   drop-future-incoming-response: func(f: future-incoming-response)
   future-incoming-response-get: func(f: future-incoming-response) -> option<result<incoming-response, error>>


### PR DESCRIPTION
This will ensure comments are set as documentation comments. That way the description will be part of output in the different language bindgen.