### PR TITLE
Use resources in wasi-http

### DIFF
--- a/proxy.md
+++ b/proxy.md
@@ -777,6 +777,7 @@ list<u8> instead of string.</p>
 <li><a name="method_fields.clone.0"></a> own&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_incoming_request.method"><code>[method]incoming-request.method: func</code></a></h4>
+<p>Returns the method of the incoming request.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_request.method.self"><code>self</code></a>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
@@ -786,6 +787,7 @@ list<u8> instead of string.</p>
 <li><a name="method_incoming_request.method.0"></a> <a href="#method"><a href="#method"><code>method</code></a></a></li>
 </ul>
 <h4><a name="method_incoming_request.path_with_query"><code>[method]incoming-request.path-with-query: func</code></a></h4>
+<p>Returns the path with query parameters from the request, as a string.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_request.path_with_query.self"><code>self</code></a>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
@@ -795,6 +797,7 @@ list<u8> instead of string.</p>
 <li><a name="method_incoming_request.path_with_query.0"></a> option&lt;<code>string</code>&gt;</li>
 </ul>
 <h4><a name="method_incoming_request.scheme"><code>[method]incoming-request.scheme: func</code></a></h4>
+<p>Returns the protocol scheme from the request.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_request.scheme.self"><code>self</code></a>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
@@ -804,6 +807,7 @@ list<u8> instead of string.</p>
 <li><a name="method_incoming_request.scheme.0"></a> option&lt;<a href="#scheme"><a href="#scheme"><code>scheme</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_incoming_request.authority"><code>[method]incoming-request.authority: func</code></a></h4>
+<p>Returns the authority from the request, if it was present.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_request.authority.self"><code>self</code></a>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
@@ -813,6 +817,7 @@ list<u8> instead of string.</p>
 <li><a name="method_incoming_request.authority.0"></a> option&lt;<code>string</code>&gt;</li>
 </ul>
 <h4><a name="method_incoming_request.headers"><code>[method]incoming-request.headers: func</code></a></h4>
+<p>Returns the headers from the request.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_request.headers.self"><code>self</code></a>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
@@ -833,6 +838,7 @@ once, subsequent calls will return error.</p>
 <li><a name="method_incoming_request.consume.0"></a> result&lt;own&lt;<a href="#incoming_body"><a href="#incoming_body"><code>incoming-body</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="constructor_outgoing_request"><code>[constructor]outgoing-request: func</code></a></h4>
+<p>Construct a new <a href="#outgoing_request"><code>outgoing-request</code></a>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="constructor_outgoing_request.method"><a href="#method"><code>method</code></a></a>: <a href="#method"><a href="#method"><code>method</code></a></a></li>
@@ -857,12 +863,15 @@ once, subsequent calls will return error.</p>
 <li><a name="method_outgoing_request.write.0"></a> result&lt;own&lt;<a href="#outgoing_body"><a href="#outgoing_body"><code>outgoing-body</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="static_response_outparam.set"><code>[static]response-outparam.set: func</code></a></h4>
+<p>Set the value of the <a href="#response_outparam"><code>response-outparam</code></a> to indicate either a response,
+or an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="static_response_outparam.set.param"><code>param</code></a>: own&lt;<a href="#response_outparam"><a href="#response_outparam"><code>response-outparam</code></a></a>&gt;</li>
 <li><a name="static_response_outparam.set.response"><code>response</code></a>: result&lt;own&lt;<a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a>&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_incoming_response.status"><code>[method]incoming-response.status: func</code></a></h4>
+<p>Returns the status code from the <a href="#incoming_response"><code>incoming-response</code></a>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_response.status.self"><code>self</code></a>: borrow&lt;<a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a>&gt;</li>
@@ -872,6 +881,7 @@ once, subsequent calls will return error.</p>
 <li><a name="method_incoming_response.status.0"></a> <a href="#status_code"><a href="#status_code"><code>status-code</code></a></a></li>
 </ul>
 <h4><a name="method_incoming_response.headers"><code>[method]incoming-response.headers: func</code></a></h4>
+<p>Returns the headers from the <a href="#incoming_response"><code>incoming-response</code></a>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_response.headers.self"><code>self</code></a>: borrow&lt;<a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a>&gt;</li>
@@ -935,6 +945,7 @@ input-stream child is still alive.</p>
 <li><a name="method_future_trailers.get.0"></a> option&lt;result&lt;own&lt;<a href="#trailers"><a href="#trailers"><code>trailers</code></a></a>&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="constructor_outgoing_response"><code>[constructor]outgoing-response: func</code></a></h4>
+<p>Construct an <a href="#outgoing_response"><code>outgoing-response</code></a>.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="constructor_outgoing_response.status_code"><a href="#status_code"><code>status-code</code></a></a>: <a href="#status_code"><a href="#status_code"><code>status-code</code></a></a></li>
@@ -989,6 +1000,8 @@ indicates whether the incoming response successfully started.</p>
 <li><a name="method_future_incoming_response.get.0"></a> option&lt;result&lt;result&lt;own&lt;<a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a>&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;&gt;</li>
 </ul>
 <h4><a name="method_future_incoming_response.subscribe"><code>[method]future-incoming-response.subscribe: func</code></a></h4>
+<p>Pollable that resolves when the <code>get</code> method will resolve to a <code>Some</code>
+result.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_future_incoming_response.subscribe.self"><code>self</code></a>: borrow&lt;<a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a>&gt;</li>

--- a/proxy.md
+++ b/proxy.md
@@ -621,6 +621,9 @@ the output stream.</p>
 <li><a name="get_stdin.0"></a> own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:http_types">Import interface wasi:http/types</a></h2>
+<p>The <a href="#wasi:http_types"><code>wasi:http/types</code></a> interface is meant to be imported by components to
+define the HTTP resource types and operations used by the component's
+imported and exported interfaces.</p>
 <hr />
 <h3>Types</h3>
 <h4><a name="input_stream"><code>type input-stream</code></a></h4>
@@ -633,6 +636,7 @@ the output stream.</p>
 [`pollable`](#pollable)
 <p>
 #### <a name="method">`variant method`</a>
+<p>This type corresponds to HTTP standard Methods.</p>
 <h5>Variant Cases</h5>
 <ul>
 <li><a name="method.get"><code>get</code></a></li>
@@ -647,6 +651,7 @@ the output stream.</p>
 <li><a name="method.other"><code>other</code></a>: <code>string</code></li>
 </ul>
 <h4><a name="scheme"><code>variant scheme</code></a></h4>
+<p>This type corresponds to HTTP standard Related Schemes.</p>
 <h5>Variant Cases</h5>
 <ul>
 <li><a name="scheme.http"><code>HTTP</code></a></li>
@@ -654,6 +659,9 @@ the output stream.</p>
 <li><a name="scheme.other"><code>other</code></a>: <code>string</code></li>
 </ul>
 <h4><a name="error"><code>variant error</code></a></h4>
+<p>TODO: perhaps better align with HTTP semantics?
+This type enumerates the different kinds of errors that may occur when
+initially returning a response.</p>
 <h5>Variant Cases</h5>
 <ul>
 <li><a name="error.invalid_url"><code>invalid-url</code></a>: <code>string</code></li>
@@ -671,17 +679,30 @@ the output stream.</p>
 #### <a name="incoming_request">`resource incoming-request`</a>
 <h4><a name="outgoing_request"><code>resource outgoing-request</code></a></h4>
 <h4><a name="request_options"><code>record request-options</code></a></h4>
+<p>Additional optional parameters that can be set when making a request.</p>
 <h5>Record Fields</h5>
 <ul>
-<li><a name="request_options.connect_timeout_ms"><code>connect-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</li>
-<li><a name="request_options.first_byte_timeout_ms"><code>first-byte-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</li>
-<li><a name="request_options.between_bytes_timeout_ms"><code>between-bytes-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</li>
+<li>
+<p><a name="request_options.connect_timeout_ms"><code>connect-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</p>
+<p>The following timeouts are specific to the HTTP protocol and work
+independently of the overall timeouts passed to `io.poll.poll-list`.
+The timeout for the initial connect.
+</li>
+<li>
+<p><a name="request_options.first_byte_timeout_ms"><code>first-byte-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</p>
+<p>The timeout for receiving the first byte of the response body.
+</li>
+<li>
+<p><a name="request_options.between_bytes_timeout_ms"><code>between-bytes-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</p>
+<p>The timeout for receiving the next chunk of bytes in the response body
+stream.
+</li>
 </ul>
 <h4><a name="response_outparam"><code>resource response-outparam</code></a></h4>
 <h4><a name="status_code"><code>type status-code</code></a></h4>
 <p><code>u16</code></p>
-<p>
-#### <a name="incoming_response">`resource incoming-response`</a>
+<p>This type corresponds to the HTTP standard Status Code.
+<h4><a name="incoming_response"><code>resource incoming-response</code></a></h4>
 <h4><a name="incoming_body"><code>resource incoming-body</code></a></h4>
 <h4><a name="future_trailers"><code>resource future-trailers</code></a></h4>
 <h4><a name="outgoing_response"><code>resource outgoing-response</code></a></h4>
@@ -690,6 +711,8 @@ the output stream.</p>
 <hr />
 <h3>Functions</h3>
 <h4><a name="constructor_fields"><code>[constructor]fields: func</code></a></h4>
+<p>Multiple values for a header are multiple entries in the list with the
+same key.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="constructor_fields.entries"><code>entries</code></a>: list&lt;(<code>string</code>, list&lt;<code>u8</code>&gt;)&gt;</li>
@@ -699,6 +722,8 @@ the output stream.</p>
 <li><a name="constructor_fields.0"></a> own&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_fields.get"><code>[method]fields.get: func</code></a></h4>
+<p>Values off wire are not necessarily well formed, so they are given by
+list<u8> instead of string.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_fields.get.self"><code>self</code></a>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
@@ -709,6 +734,8 @@ the output stream.</p>
 <li><a name="method_fields.get.0"></a> list&lt;list&lt;<code>u8</code>&gt;&gt;</li>
 </ul>
 <h4><a name="method_fields.set"><code>[method]fields.set: func</code></a></h4>
+<p>Values off wire are not necessarily well formed, so they are given by
+list<u8> instead of string.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_fields.set.self"><code>self</code></a>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
@@ -729,6 +756,8 @@ the output stream.</p>
 <li><a name="method_fields.append.value"><code>value</code></a>: list&lt;<code>u8</code>&gt;</li>
 </ul>
 <h4><a name="method_fields.entries"><code>[method]fields.entries: func</code></a></h4>
+<p>Values off wire are not necessarily well formed, so they are given by
+list<u8> instead of string.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_fields.entries.self"><code>self</code></a>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
@@ -738,6 +767,7 @@ the output stream.</p>
 <li><a name="method_fields.entries.0"></a> list&lt;(<code>string</code>, list&lt;<code>u8</code>&gt;)&gt;</li>
 </ul>
 <h4><a name="method_fields.clone"><code>[method]fields.clone: func</code></a></h4>
+<p>Deep copy of all contents in a fields.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_fields.clone.self"><code>self</code></a>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
@@ -792,6 +822,8 @@ the output stream.</p>
 <li><a name="method_incoming_request.headers.0"></a> own&lt;<a href="#headers"><a href="#headers"><code>headers</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_incoming_request.consume"><code>[method]incoming-request.consume: func</code></a></h4>
+<p>Will return the incoming-body child at most once. If called more than
+once, subsequent calls will return error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_request.consume.self"><code>self</code></a>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
@@ -814,6 +846,8 @@ the output stream.</p>
 <li><a name="constructor_outgoing_request.0"></a> own&lt;<a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_outgoing_request.write"><code>[method]outgoing-request.write: func</code></a></h4>
+<p>Will return the outgoing-body child at most once. If called more than
+once, subsequent calls will return error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_outgoing_request.write.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a>&gt;</li>
@@ -847,6 +881,7 @@ the output stream.</p>
 <li><a name="method_incoming_response.headers.0"></a> own&lt;<a href="#headers"><a href="#headers"><code>headers</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_incoming_response.consume"><code>[method]incoming-response.consume: func</code></a></h4>
+<p>May be called at most once. returns error if called additional times.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_response.consume.self"><code>self</code></a>: borrow&lt;<a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a>&gt;</li>
@@ -856,6 +891,10 @@ the output stream.</p>
 <li><a name="method_incoming_response.consume.0"></a> result&lt;own&lt;<a href="#incoming_body"><a href="#incoming_body"><code>incoming-body</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="method_incoming_body.stream"><code>[method]incoming-body.stream: func</code></a></h4>
+<p>returned input-stream is a child - the implementation may trap if
+incoming-body is dropped (or consumed by call to
+incoming-body.finish) before the input-stream is dropped.
+May be called at most once. Returns error if called additional times.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_body.stream.self"><code>self</code></a>: borrow&lt;<a href="#incoming_body"><a href="#incoming_body"><code>incoming-body</code></a></a>&gt;</li>
@@ -865,6 +904,8 @@ the output stream.</p>
 <li><a name="method_incoming_body.stream.0"></a> result&lt;own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="static_incoming_body.finish"><code>[static]incoming-body.finish: func</code></a></h4>
+<p>Takes ownership of incoming-body and will trap if the
+input-stream child is still alive.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="static_incoming_body.finish.this"><code>this</code></a>: own&lt;<a href="#incoming_body"><a href="#incoming_body"><code>incoming-body</code></a></a>&gt;</li>
@@ -874,8 +915,7 @@ the output stream.</p>
 <li><a name="static_incoming_body.finish.0"></a> own&lt;<a href="#future_trailers"><a href="#future_trailers"><code>future-trailers</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_future_trailers.subscribe"><code>[method]future-trailers.subscribe: func</code></a></h4>
-<p>Pollable that resolves when the body has been fully read, and the trailers
-are ready to be consumed.</p>
+<p>Pollable that resolves when the the trailers are ready to be consumed.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_future_trailers.subscribe.self"><code>self</code></a>: borrow&lt;<a href="#future_trailers"><a href="#future_trailers"><code>future-trailers</code></a></a>&gt;</li>
@@ -905,8 +945,8 @@ are ready to be consumed.</p>
 <li><a name="constructor_outgoing_response.0"></a> own&lt;<a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_outgoing_response.write"><code>[method]outgoing-response.write: func</code></a></h4>
-<p>Will give the child outgoing-response at most once. subsequent calls will
-return an error.</p>
+<p>Will give the child outgoing-response at most once. subsequent calls
+will return an error.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_outgoing_response.write.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a>&gt;</li>
@@ -928,8 +968,8 @@ return an error.</p>
 </ul>
 <h4><a name="static_outgoing_body.finish"><code>[static]outgoing-body.finish: func</code></a></h4>
 <p>Finalize an outgoing body, optionally providing trailers. This must be
-called to signal that the response is complete. If the <a href="#outgoing_body"><code>outgoing-body</code></a> is
-dropped without calling <code>outgoing-body-finalize</code>, the implementation
+called to signal that the response is complete. If the <a href="#outgoing_body"><code>outgoing-body</code></a>
+is dropped without calling <code>outgoing-body.finalize</code>, the implementation
 should treat the body as corrupted.</p>
 <h5>Params</h5>
 <ul>
@@ -937,12 +977,9 @@ should treat the body as corrupted.</p>
 <li><a name="static_outgoing_body.finish.trailers"><a href="#trailers"><code>trailers</code></a></a>: option&lt;own&lt;<a href="#trailers"><a href="#trailers"><code>trailers</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="method_future_incoming_response.get"><code>[method]future-incoming-response.get: func</code></a></h4>
-<p>option indicates readiness.
-outer result indicates you are allowed to get the
-incoming-response-or-error at most once. subsequent calls after ready
-will return an error here.
-inner result indicates whether the incoming-response was available, or an
-error occured.</p>
+<p>The option indicates readiness. The outer result must return failure if
+<code>get</code> is called after returning a non-empty result.  The inner result
+indicates whether the incoming response successfully started.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_future_incoming_response.get.self"><code>self</code></a>: borrow&lt;<a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a>&gt;</li>

--- a/proxy.md
+++ b/proxy.md
@@ -661,368 +661,304 @@ the output stream.</p>
 <li><a name="error.protocol_error"><code>protocol-error</code></a>: <code>string</code></li>
 <li><a name="error.unexpected_error"><code>unexpected-error</code></a>: <code>string</code></li>
 </ul>
-<h4><a name="fields"><code>type fields</code></a></h4>
-<p><code>u32</code></p>
-<p>
-#### <a name="headers">`type headers`</a>
-[`fields`](#fields)
+<h4><a name="fields"><code>resource fields</code></a></h4>
+<h4><a name="headers"><code>type headers</code></a></h4>
+<p><a href="#fields"><a href="#fields"><code>fields</code></a></a></p>
 <p>
 #### <a name="trailers">`type trailers`</a>
 [`fields`](#fields)
 <p>
-#### <a name="incoming_stream">`type incoming-stream`</a>
-[`input-stream`](#input_stream)
-<p>
-#### <a name="outgoing_stream">`type outgoing-stream`</a>
-[`output-stream`](#output_stream)
-<p>
-#### <a name="future_trailers">`type future-trailers`</a>
-`u32`
-<p>
-#### <a name="future_write_trailers_result">`type future-write-trailers-result`</a>
-`u32`
-<p>
-#### <a name="incoming_request">`type incoming-request`</a>
-`u32`
-<p>
-#### <a name="outgoing_request">`type outgoing-request`</a>
-`u32`
-<p>
-#### <a name="request_options">`record request-options`</a>
+#### <a name="incoming_request">`resource incoming-request`</a>
+<h4><a name="outgoing_request"><code>resource outgoing-request</code></a></h4>
+<h4><a name="request_options"><code>record request-options</code></a></h4>
 <h5>Record Fields</h5>
 <ul>
 <li><a name="request_options.connect_timeout_ms"><code>connect-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</li>
 <li><a name="request_options.first_byte_timeout_ms"><code>first-byte-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</li>
 <li><a name="request_options.between_bytes_timeout_ms"><code>between-bytes-timeout-ms</code></a>: option&lt;<code>u32</code>&gt;</li>
 </ul>
-<h4><a name="response_outparam"><code>type response-outparam</code></a></h4>
-<p><code>u32</code></p>
+<h4><a name="response_outparam"><code>resource response-outparam</code></a></h4>
+<h4><a name="status_code"><code>type status-code</code></a></h4>
+<p><code>u16</code></p>
 <p>
-#### <a name="status_code">`type status-code`</a>
-`u16`
-<p>
-#### <a name="incoming_response">`type incoming-response`</a>
-`u32`
-<p>
-#### <a name="outgoing_response">`type outgoing-response`</a>
-`u32`
-<p>
-#### <a name="future_incoming_response">`type future-incoming-response`</a>
-`u32`
-<p>
-----
+#### <a name="incoming_response">`resource incoming-response`</a>
+<h4><a name="incoming_body"><code>resource incoming-body</code></a></h4>
+<h4><a name="future_trailers"><code>resource future-trailers</code></a></h4>
+<h4><a name="outgoing_response"><code>resource outgoing-response</code></a></h4>
+<h4><a name="outgoing_body"><code>resource outgoing-body</code></a></h4>
+<h4><a name="future_incoming_response"><code>resource future-incoming-response</code></a></h4>
+<hr />
 <h3>Functions</h3>
-<h4><a name="drop_fields"><code>drop-fields: func</code></a></h4>
+<h4><a name="constructor_fields"><code>[constructor]fields: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="drop_fields.fields"><a href="#fields"><code>fields</code></a></a>: <a href="#fields"><a href="#fields"><code>fields</code></a></a></li>
-</ul>
-<h4><a name="new_fields"><code>new-fields: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="new_fields.entries"><code>entries</code></a>: list&lt;(<code>string</code>, list&lt;<code>u8</code>&gt;)&gt;</li>
+<li><a name="constructor_fields.entries"><code>entries</code></a>: list&lt;(<code>string</code>, list&lt;<code>u8</code>&gt;)&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="new_fields.0"></a> <a href="#fields"><a href="#fields"><code>fields</code></a></a></li>
+<li><a name="constructor_fields.0"></a> own&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
 </ul>
-<h4><a name="fields_get"><code>fields-get: func</code></a></h4>
+<h4><a name="method_fields.get"><code>[method]fields.get: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="fields_get.fields"><a href="#fields"><code>fields</code></a></a>: <a href="#fields"><a href="#fields"><code>fields</code></a></a></li>
-<li><a name="fields_get.name"><code>name</code></a>: <code>string</code></li>
+<li><a name="method_fields.get.self"><code>self</code></a>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
+<li><a name="method_fields.get.name"><code>name</code></a>: <code>string</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="fields_get.0"></a> list&lt;list&lt;<code>u8</code>&gt;&gt;</li>
+<li><a name="method_fields.get.0"></a> list&lt;list&lt;<code>u8</code>&gt;&gt;</li>
 </ul>
-<h4><a name="fields_set"><code>fields-set: func</code></a></h4>
+<h4><a name="method_fields.set"><code>[method]fields.set: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="fields_set.fields"><a href="#fields"><code>fields</code></a></a>: <a href="#fields"><a href="#fields"><code>fields</code></a></a></li>
-<li><a name="fields_set.name"><code>name</code></a>: <code>string</code></li>
-<li><a name="fields_set.value"><code>value</code></a>: list&lt;list&lt;<code>u8</code>&gt;&gt;</li>
+<li><a name="method_fields.set.self"><code>self</code></a>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
+<li><a name="method_fields.set.name"><code>name</code></a>: <code>string</code></li>
+<li><a name="method_fields.set.value"><code>value</code></a>: list&lt;list&lt;<code>u8</code>&gt;&gt;</li>
 </ul>
-<h4><a name="fields_delete"><code>fields-delete: func</code></a></h4>
+<h4><a name="method_fields.delete"><code>[method]fields.delete: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="fields_delete.fields"><a href="#fields"><code>fields</code></a></a>: <a href="#fields"><a href="#fields"><code>fields</code></a></a></li>
-<li><a name="fields_delete.name"><code>name</code></a>: <code>string</code></li>
+<li><a name="method_fields.delete.self"><code>self</code></a>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
+<li><a name="method_fields.delete.name"><code>name</code></a>: <code>string</code></li>
 </ul>
-<h4><a name="fields_append"><code>fields-append: func</code></a></h4>
+<h4><a name="method_fields.append"><code>[method]fields.append: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="fields_append.fields"><a href="#fields"><code>fields</code></a></a>: <a href="#fields"><a href="#fields"><code>fields</code></a></a></li>
-<li><a name="fields_append.name"><code>name</code></a>: <code>string</code></li>
-<li><a name="fields_append.value"><code>value</code></a>: list&lt;<code>u8</code>&gt;</li>
+<li><a name="method_fields.append.self"><code>self</code></a>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
+<li><a name="method_fields.append.name"><code>name</code></a>: <code>string</code></li>
+<li><a name="method_fields.append.value"><code>value</code></a>: list&lt;<code>u8</code>&gt;</li>
 </ul>
-<h4><a name="fields_entries"><code>fields-entries: func</code></a></h4>
+<h4><a name="method_fields.entries"><code>[method]fields.entries: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="fields_entries.fields"><a href="#fields"><code>fields</code></a></a>: <a href="#fields"><a href="#fields"><code>fields</code></a></a></li>
+<li><a name="method_fields.entries.self"><code>self</code></a>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="fields_entries.0"></a> list&lt;(<code>string</code>, list&lt;<code>u8</code>&gt;)&gt;</li>
+<li><a name="method_fields.entries.0"></a> list&lt;(<code>string</code>, list&lt;<code>u8</code>&gt;)&gt;</li>
 </ul>
-<h4><a name="fields_clone"><code>fields-clone: func</code></a></h4>
+<h4><a name="method_fields.clone"><code>[method]fields.clone: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="fields_clone.fields"><a href="#fields"><code>fields</code></a></a>: <a href="#fields"><a href="#fields"><code>fields</code></a></a></li>
+<li><a name="method_fields.clone.self"><code>self</code></a>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="fields_clone.0"></a> <a href="#fields"><a href="#fields"><code>fields</code></a></a></li>
+<li><a name="method_fields.clone.0"></a> own&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
 </ul>
-<h4><a name="finish_incoming_stream"><code>finish-incoming-stream: func</code></a></h4>
+<h4><a name="method_incoming_request.method"><code>[method]incoming-request.method: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="finish_incoming_stream.s"><code>s</code></a>: own&lt;<a href="#incoming_stream"><a href="#incoming_stream"><code>incoming-stream</code></a></a>&gt;</li>
+<li><a name="method_incoming_request.method.self"><code>self</code></a>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="finish_incoming_stream.0"></a> option&lt;<a href="#future_trailers"><a href="#future_trailers"><code>future-trailers</code></a></a>&gt;</li>
+<li><a name="method_incoming_request.method.0"></a> <a href="#method"><a href="#method"><code>method</code></a></a></li>
 </ul>
-<h4><a name="finish_outgoing_stream"><code>finish-outgoing-stream: func</code></a></h4>
+<h4><a name="method_incoming_request.path_with_query"><code>[method]incoming-request.path-with-query: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="finish_outgoing_stream.s"><code>s</code></a>: own&lt;<a href="#outgoing_stream"><a href="#outgoing_stream"><code>outgoing-stream</code></a></a>&gt;</li>
-</ul>
-<h4><a name="finish_outgoing_stream_with_trailers"><code>finish-outgoing-stream-with-trailers: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="finish_outgoing_stream_with_trailers.s"><code>s</code></a>: own&lt;<a href="#outgoing_stream"><a href="#outgoing_stream"><code>outgoing-stream</code></a></a>&gt;</li>
-<li><a name="finish_outgoing_stream_with_trailers.trailers"><a href="#trailers"><code>trailers</code></a></a>: <a href="#trailers"><a href="#trailers"><code>trailers</code></a></a></li>
+<li><a name="method_incoming_request.path_with_query.self"><code>self</code></a>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="finish_outgoing_stream_with_trailers.0"></a> <a href="#future_write_trailers_result"><a href="#future_write_trailers_result"><code>future-write-trailers-result</code></a></a></li>
+<li><a name="method_incoming_request.path_with_query.0"></a> option&lt;<code>string</code>&gt;</li>
 </ul>
-<h4><a name="drop_future_trailers"><code>drop-future-trailers: func</code></a></h4>
+<h4><a name="method_incoming_request.scheme"><code>[method]incoming-request.scheme: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="drop_future_trailers.f"><code>f</code></a>: <a href="#future_trailers"><a href="#future_trailers"><code>future-trailers</code></a></a></li>
-</ul>
-<h4><a name="future_trailers_get"><code>future-trailers-get: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="future_trailers_get.f"><code>f</code></a>: <a href="#future_trailers"><a href="#future_trailers"><code>future-trailers</code></a></a></li>
+<li><a name="method_incoming_request.scheme.self"><code>self</code></a>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="future_trailers_get.0"></a> option&lt;result&lt;<a href="#trailers"><a href="#trailers"><code>trailers</code></a></a>, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
+<li><a name="method_incoming_request.scheme.0"></a> option&lt;<a href="#scheme"><a href="#scheme"><code>scheme</code></a></a>&gt;</li>
 </ul>
-<h4><a name="listen_to_future_trailers"><code>listen-to-future-trailers: func</code></a></h4>
+<h4><a name="method_incoming_request.authority"><code>[method]incoming-request.authority: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="listen_to_future_trailers.f"><code>f</code></a>: <a href="#future_trailers"><a href="#future_trailers"><code>future-trailers</code></a></a></li>
+<li><a name="method_incoming_request.authority.self"><code>self</code></a>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="listen_to_future_trailers.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
+<li><a name="method_incoming_request.authority.0"></a> option&lt;<code>string</code>&gt;</li>
 </ul>
-<h4><a name="drop_future_write_trailers_result"><code>drop-future-write-trailers-result: func</code></a></h4>
+<h4><a name="method_incoming_request.headers"><code>[method]incoming-request.headers: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="drop_future_write_trailers_result.f"><code>f</code></a>: <a href="#future_write_trailers_result"><a href="#future_write_trailers_result"><code>future-write-trailers-result</code></a></a></li>
-</ul>
-<h4><a name="future_write_trailers_result_get"><code>future-write-trailers-result-get: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="future_write_trailers_result_get.f"><code>f</code></a>: <a href="#future_write_trailers_result"><a href="#future_write_trailers_result"><code>future-write-trailers-result</code></a></a></li>
+<li><a name="method_incoming_request.headers.self"><code>self</code></a>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="future_write_trailers_result_get.0"></a> option&lt;result&lt;_, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
+<li><a name="method_incoming_request.headers.0"></a> own&lt;<a href="#headers"><a href="#headers"><code>headers</code></a></a>&gt;</li>
 </ul>
-<h4><a name="listen_to_future_write_trailers_result"><code>listen-to-future-write-trailers-result: func</code></a></h4>
+<h4><a name="method_incoming_request.consume"><code>[method]incoming-request.consume: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="listen_to_future_write_trailers_result.f"><code>f</code></a>: <a href="#future_write_trailers_result"><a href="#future_write_trailers_result"><code>future-write-trailers-result</code></a></a></li>
+<li><a name="method_incoming_request.consume.self"><code>self</code></a>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="listen_to_future_write_trailers_result.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
+<li><a name="method_incoming_request.consume.0"></a> result&lt;own&lt;<a href="#incoming_body"><a href="#incoming_body"><code>incoming-body</code></a></a>&gt;&gt;</li>
 </ul>
-<h4><a name="drop_incoming_request"><code>drop-incoming-request: func</code></a></h4>
+<h4><a name="constructor_outgoing_request"><code>[constructor]outgoing-request: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="drop_incoming_request.request"><code>request</code></a>: <a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a></li>
-</ul>
-<h4><a name="drop_outgoing_request"><code>drop-outgoing-request: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="drop_outgoing_request.request"><code>request</code></a>: <a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a></li>
-</ul>
-<h4><a name="incoming_request_method"><code>incoming-request-method: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="incoming_request_method.request"><code>request</code></a>: <a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a></li>
+<li><a name="constructor_outgoing_request.method"><a href="#method"><code>method</code></a></a>: <a href="#method"><a href="#method"><code>method</code></a></a></li>
+<li><a name="constructor_outgoing_request.path_with_query"><code>path-with-query</code></a>: option&lt;<code>string</code>&gt;</li>
+<li><a name="constructor_outgoing_request.scheme"><a href="#scheme"><code>scheme</code></a></a>: option&lt;<a href="#scheme"><a href="#scheme"><code>scheme</code></a></a>&gt;</li>
+<li><a name="constructor_outgoing_request.authority"><code>authority</code></a>: option&lt;<code>string</code>&gt;</li>
+<li><a name="constructor_outgoing_request.headers"><a href="#headers"><code>headers</code></a></a>: borrow&lt;<a href="#headers"><a href="#headers"><code>headers</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="incoming_request_method.0"></a> <a href="#method"><a href="#method"><code>method</code></a></a></li>
+<li><a name="constructor_outgoing_request.0"></a> own&lt;<a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a>&gt;</li>
 </ul>
-<h4><a name="incoming_request_path_with_query"><code>incoming-request-path-with-query: func</code></a></h4>
+<h4><a name="method_outgoing_request.write"><code>[method]outgoing-request.write: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="incoming_request_path_with_query.request"><code>request</code></a>: <a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a></li>
+<li><a name="method_outgoing_request.write.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="incoming_request_path_with_query.0"></a> option&lt;<code>string</code>&gt;</li>
+<li><a name="method_outgoing_request.write.0"></a> result&lt;own&lt;<a href="#outgoing_body"><a href="#outgoing_body"><code>outgoing-body</code></a></a>&gt;&gt;</li>
 </ul>
-<h4><a name="incoming_request_scheme"><code>incoming-request-scheme: func</code></a></h4>
+<h4><a name="static_response_outparam.set"><code>[static]response-outparam.set: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="incoming_request_scheme.request"><code>request</code></a>: <a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a></li>
+<li><a name="static_response_outparam.set.param"><code>param</code></a>: own&lt;<a href="#response_outparam"><a href="#response_outparam"><code>response-outparam</code></a></a>&gt;</li>
+<li><a name="static_response_outparam.set.response"><code>response</code></a>: result&lt;own&lt;<a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a>&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+</ul>
+<h4><a name="method_incoming_response.status"><code>[method]incoming-response.status: func</code></a></h4>
+<h5>Params</h5>
+<ul>
+<li><a name="method_incoming_response.status.self"><code>self</code></a>: borrow&lt;<a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="incoming_request_scheme.0"></a> option&lt;<a href="#scheme"><a href="#scheme"><code>scheme</code></a></a>&gt;</li>
+<li><a name="method_incoming_response.status.0"></a> <a href="#status_code"><a href="#status_code"><code>status-code</code></a></a></li>
 </ul>
-<h4><a name="incoming_request_authority"><code>incoming-request-authority: func</code></a></h4>
+<h4><a name="method_incoming_response.headers"><code>[method]incoming-response.headers: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="incoming_request_authority.request"><code>request</code></a>: <a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a></li>
+<li><a name="method_incoming_response.headers.self"><code>self</code></a>: borrow&lt;<a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="incoming_request_authority.0"></a> option&lt;<code>string</code>&gt;</li>
+<li><a name="method_incoming_response.headers.0"></a> own&lt;<a href="#headers"><a href="#headers"><code>headers</code></a></a>&gt;</li>
 </ul>
-<h4><a name="incoming_request_headers"><code>incoming-request-headers: func</code></a></h4>
+<h4><a name="method_incoming_response.consume"><code>[method]incoming-response.consume: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="incoming_request_headers.request"><code>request</code></a>: <a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a></li>
+<li><a name="method_incoming_response.consume.self"><code>self</code></a>: borrow&lt;<a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="incoming_request_headers.0"></a> <a href="#headers"><a href="#headers"><code>headers</code></a></a></li>
+<li><a name="method_incoming_response.consume.0"></a> result&lt;own&lt;<a href="#incoming_body"><a href="#incoming_body"><code>incoming-body</code></a></a>&gt;&gt;</li>
 </ul>
-<h4><a name="incoming_request_consume"><code>incoming-request-consume: func</code></a></h4>
+<h4><a name="method_incoming_body.stream"><code>[method]incoming-body.stream: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="incoming_request_consume.request"><code>request</code></a>: <a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a></li>
+<li><a name="method_incoming_body.stream.self"><code>self</code></a>: borrow&lt;<a href="#incoming_body"><a href="#incoming_body"><code>incoming-body</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="incoming_request_consume.0"></a> result&lt;own&lt;<a href="#incoming_stream"><a href="#incoming_stream"><code>incoming-stream</code></a></a>&gt;&gt;</li>
+<li><a name="method_incoming_body.stream.0"></a> result&lt;own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;&gt;</li>
 </ul>
-<h4><a name="new_outgoing_request"><code>new-outgoing-request: func</code></a></h4>
+<h4><a name="static_incoming_body.finish"><code>[static]incoming-body.finish: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="new_outgoing_request.method"><a href="#method"><code>method</code></a></a>: <a href="#method"><a href="#method"><code>method</code></a></a></li>
-<li><a name="new_outgoing_request.path_with_query"><code>path-with-query</code></a>: option&lt;<code>string</code>&gt;</li>
-<li><a name="new_outgoing_request.scheme"><a href="#scheme"><code>scheme</code></a></a>: option&lt;<a href="#scheme"><a href="#scheme"><code>scheme</code></a></a>&gt;</li>
-<li><a name="new_outgoing_request.authority"><code>authority</code></a>: option&lt;<code>string</code>&gt;</li>
-<li><a name="new_outgoing_request.headers"><a href="#headers"><code>headers</code></a></a>: <a href="#headers"><a href="#headers"><code>headers</code></a></a></li>
+<li><a name="static_incoming_body.finish.this"><code>this</code></a>: own&lt;<a href="#incoming_body"><a href="#incoming_body"><code>incoming-body</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="new_outgoing_request.0"></a> result&lt;<a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a>, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a name="static_incoming_body.finish.0"></a> own&lt;<a href="#future_trailers"><a href="#future_trailers"><code>future-trailers</code></a></a>&gt;</li>
 </ul>
-<h4><a name="outgoing_request_write"><code>outgoing-request-write: func</code></a></h4>
+<h4><a name="method_future_trailers.subscribe"><code>[method]future-trailers.subscribe: func</code></a></h4>
+<p>Pollable that resolves when the body has been fully read, and the trailers
+are ready to be consumed.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="outgoing_request_write.request"><code>request</code></a>: <a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a></li>
+<li><a name="method_future_trailers.subscribe.self"><code>self</code></a>: borrow&lt;<a href="#future_trailers"><a href="#future_trailers"><code>future-trailers</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="outgoing_request_write.0"></a> result&lt;own&lt;<a href="#outgoing_stream"><a href="#outgoing_stream"><code>outgoing-stream</code></a></a>&gt;&gt;</li>
+<li><a name="method_future_trailers.subscribe.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
 </ul>
-<h4><a name="drop_response_outparam"><code>drop-response-outparam: func</code></a></h4>
+<h4><a name="method_future_trailers.get"><code>[method]future-trailers.get: func</code></a></h4>
+<p>Retrieve reference to trailers, if they are ready.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="drop_response_outparam.response"><code>response</code></a>: <a href="#response_outparam"><a href="#response_outparam"><code>response-outparam</code></a></a></li>
-</ul>
-<h4><a name="set_response_outparam"><code>set-response-outparam: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="set_response_outparam.param"><code>param</code></a>: <a href="#response_outparam"><a href="#response_outparam"><code>response-outparam</code></a></a></li>
-<li><a name="set_response_outparam.response"><code>response</code></a>: result&lt;<a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a>, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a name="method_future_trailers.get.self"><code>self</code></a>: borrow&lt;<a href="#future_trailers"><a href="#future_trailers"><code>future-trailers</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_response_outparam.0"></a> result</li>
+<li><a name="method_future_trailers.get.0"></a> option&lt;result&lt;own&lt;<a href="#trailers"><a href="#trailers"><code>trailers</code></a></a>&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
-<h4><a name="drop_incoming_response"><code>drop-incoming-response: func</code></a></h4>
+<h4><a name="constructor_outgoing_response"><code>[constructor]outgoing-response: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="drop_incoming_response.response"><code>response</code></a>: <a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a></li>
-</ul>
-<h4><a name="drop_outgoing_response"><code>drop-outgoing-response: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="drop_outgoing_response.response"><code>response</code></a>: <a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a></li>
-</ul>
-<h4><a name="incoming_response_status"><code>incoming-response-status: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="incoming_response_status.response"><code>response</code></a>: <a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a></li>
+<li><a name="constructor_outgoing_response.status_code"><a href="#status_code"><code>status-code</code></a></a>: <a href="#status_code"><a href="#status_code"><code>status-code</code></a></a></li>
+<li><a name="constructor_outgoing_response.headers"><a href="#headers"><code>headers</code></a></a>: borrow&lt;<a href="#headers"><a href="#headers"><code>headers</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="incoming_response_status.0"></a> <a href="#status_code"><a href="#status_code"><code>status-code</code></a></a></li>
+<li><a name="constructor_outgoing_response.0"></a> own&lt;<a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a>&gt;</li>
 </ul>
-<h4><a name="incoming_response_headers"><code>incoming-response-headers: func</code></a></h4>
+<h4><a name="method_outgoing_response.write"><code>[method]outgoing-response.write: func</code></a></h4>
+<p>Will give the child outgoing-response at most once. subsequent calls will
+return an error.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="incoming_response_headers.response"><code>response</code></a>: <a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a></li>
+<li><a name="method_outgoing_response.write.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="incoming_response_headers.0"></a> <a href="#headers"><a href="#headers"><code>headers</code></a></a></li>
+<li><a name="method_outgoing_response.write.0"></a> result&lt;own&lt;<a href="#outgoing_body"><a href="#outgoing_body"><code>outgoing-body</code></a></a>&gt;&gt;</li>
 </ul>
-<h4><a name="incoming_response_consume"><code>incoming-response-consume: func</code></a></h4>
+<h4><a name="method_outgoing_body.write"><code>[method]outgoing-body.write: func</code></a></h4>
+<p>Will give the child output-stream at most once. subsequent calls will
+return an error.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="incoming_response_consume.response"><code>response</code></a>: <a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a></li>
+<li><a name="method_outgoing_body.write.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_body"><a href="#outgoing_body"><code>outgoing-body</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="incoming_response_consume.0"></a> result&lt;own&lt;<a href="#incoming_stream"><a href="#incoming_stream"><code>incoming-stream</code></a></a>&gt;&gt;</li>
+<li><a name="method_outgoing_body.write.0"></a> result&lt;own&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>&gt;&gt;</li>
 </ul>
-<h4><a name="new_outgoing_response"><code>new-outgoing-response: func</code></a></h4>
+<h4><a name="static_outgoing_body.finish"><code>[static]outgoing-body.finish: func</code></a></h4>
+<p>Finalize an outgoing body, optionally providing trailers. This must be
+called to signal that the response is complete. If the <a href="#outgoing_body"><code>outgoing-body</code></a> is
+dropped without calling <code>outgoing-body-finalize</code>, the implementation
+should treat the body as corrupted.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="new_outgoing_response.status_code"><a href="#status_code"><code>status-code</code></a></a>: <a href="#status_code"><a href="#status_code"><code>status-code</code></a></a></li>
-<li><a name="new_outgoing_response.headers"><a href="#headers"><code>headers</code></a></a>: <a href="#headers"><a href="#headers"><code>headers</code></a></a></li>
+<li><a name="static_outgoing_body.finish.this"><code>this</code></a>: own&lt;<a href="#outgoing_body"><a href="#outgoing_body"><code>outgoing-body</code></a></a>&gt;</li>
+<li><a name="static_outgoing_body.finish.trailers"><a href="#trailers"><code>trailers</code></a></a>: option&lt;own&lt;<a href="#trailers"><a href="#trailers"><code>trailers</code></a></a>&gt;&gt;</li>
+</ul>
+<h4><a name="method_future_incoming_response.get"><code>[method]future-incoming-response.get: func</code></a></h4>
+<p>option indicates readiness.
+outer result indicates you are allowed to get the
+incoming-response-or-error at most once. subsequent calls after ready
+will return an error here.
+inner result indicates whether the incoming-response was available, or an
+error occured.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="method_future_incoming_response.get.self"><code>self</code></a>: borrow&lt;<a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="new_outgoing_response.0"></a> result&lt;<a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a>, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a name="method_future_incoming_response.get.0"></a> option&lt;result&lt;result&lt;own&lt;<a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a>&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;&gt;</li>
 </ul>
-<h4><a name="outgoing_response_write"><code>outgoing-response-write: func</code></a></h4>
+<h4><a name="method_future_incoming_response.subscribe"><code>[method]future-incoming-response.subscribe: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="outgoing_response_write.response"><code>response</code></a>: <a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a></li>
+<li><a name="method_future_incoming_response.subscribe.self"><code>self</code></a>: borrow&lt;<a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="outgoing_response_write.0"></a> result&lt;own&lt;<a href="#outgoing_stream"><a href="#outgoing_stream"><code>outgoing-stream</code></a></a>&gt;&gt;</li>
-</ul>
-<h4><a name="drop_future_incoming_response"><code>drop-future-incoming-response: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="drop_future_incoming_response.f"><code>f</code></a>: <a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a></li>
-</ul>
-<h4><a name="future_incoming_response_get"><code>future-incoming-response-get: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="future_incoming_response_get.f"><code>f</code></a>: <a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a></li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="future_incoming_response_get.0"></a> option&lt;result&lt;<a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a>, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
-</ul>
-<h4><a name="listen_to_future_incoming_response"><code>listen-to-future-incoming-response: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="listen_to_future_incoming_response.f"><code>f</code></a>: <a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a></li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="listen_to_future_incoming_response.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
+<li><a name="method_future_incoming_response.subscribe.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:http_outgoing_handler">Import interface wasi:http/outgoing-handler</a></h2>
 <hr />
@@ -1036,17 +972,20 @@ the output stream.</p>
 #### <a name="future_incoming_response">`type future-incoming-response`</a>
 [`future-incoming-response`](#future_incoming_response)
 <p>
+#### <a name="error">`type error`</a>
+[`error`](#error)
+<p>
 ----
 <h3>Functions</h3>
 <h4><a name="handle"><code>handle: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="handle.request"><code>request</code></a>: <a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a></li>
+<li><a name="handle.request"><code>request</code></a>: own&lt;<a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a>&gt;</li>
 <li><a name="handle.options"><code>options</code></a>: option&lt;<a href="#request_options"><a href="#request_options"><code>request-options</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="handle.0"></a> <a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a></li>
+<li><a name="handle.0"></a> result&lt;own&lt;<a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a>&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:http_incoming_handler">Export interface wasi:http/incoming-handler</a></h2>
 <hr />
@@ -1062,6 +1001,6 @@ the output stream.</p>
 <h4><a name="handle"><code>handle: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="handle.request"><code>request</code></a>: <a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a></li>
-<li><a name="handle.response_out"><code>response-out</code></a>: <a href="#response_outparam"><a href="#response_outparam"><code>response-outparam</code></a></a></li>
+<li><a name="handle.request"><code>request</code></a>: own&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
+<li><a name="handle.response_out"><code>response-out</code></a>: own&lt;<a href="#response_outparam"><a href="#response_outparam"><code>response-outparam</code></a></a>&gt;</li>
 </ul>

--- a/wit/handler.wit
+++ b/wit/handler.wit
@@ -12,13 +12,11 @@ interface incoming-handler {
   // The `handle` function takes an outparam instead of returning its response
   // so that the component may stream its response while streaming any other
   // request or response bodies. The callee MUST write a response to the
-  // `response-out` and then finish the response before returning. The caller
-  // is expected to start streaming the response once `set-response-outparam`
-  // is called and finish streaming the response when `drop-response-outparam`
-  // is called. The `handle` function is then allowed to continue executing
-  // any post-response logic before returning. While this post-response
-  // execution is taken off the critical path, since there is no return value,
-  // there is no way to report its success or failure.
+  // `response-outparam` and then finish the response before returning. The `handle`
+  // function is allowed to continue execution after finishing the response's
+  // output stream. While this post-response execution is taken off the
+  // critical path, since there is no return value, there is no way to report
+  // its success or failure.
   handle: func(
     request: incoming-request,
     response-out: response-outparam
@@ -33,13 +31,15 @@ interface incoming-handler {
 //   that takes a `request` parameter and returns a `response` result.
 //
 interface outgoing-handler {
-  use types.{outgoing-request, request-options, future-incoming-response};
+  use types.{outgoing-request, request-options, future-incoming-response, error};
 
   // The parameter and result types of the `handle` function allow the caller
   // to concurrently stream the bodies of the outgoing request and the incoming
   // response.
+  // Consumes the outgoing-request. Gives an error if the outgoing-request
+  // is invalid or cannot be satisfied by this handler.
   handle: func(
     request: outgoing-request,
     options: option<request-options>
-  ) -> future-incoming-response;
+  ) -> result<future-incoming-response, error>;
 }

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -154,18 +154,17 @@ interface types {
   resource incoming-body {
     // returned input-stream is a child - the implementation may trap if
     // incoming-body is dropped (or consumed by call to
-    // incoming-body-finish) before the input-stream is dropped.
-    // May be called at most once. returns error if called additional times.
+    // incoming-body.finish) before the input-stream is dropped.
+    // May be called at most once. Returns error if called additional times.
     %stream: func() -> result<input-stream>;
 
-    // takes ownership of incoming-body. this will trap if the
-    // incoming-body-stream child is still alive!
+    // Takes ownership of incoming-body and will trap if the
+    // input-stream child is still alive.
     finish: static func(this: incoming-body) -> future-trailers;
   }
 
   resource future-trailers {
-    /// Pollable that resolves when the body has been fully read, and the trailers
-    /// are ready to be consumed.
+    /// Pollable that resolves when the the trailers are ready to be consumed.
     subscribe: func() -> pollable;
 
     /// Retrieve reference to trailers, if they are ready.
@@ -187,7 +186,7 @@ interface types {
 
     /// Finalize an outgoing body, optionally providing trailers. This must be
     /// called to signal that the response is complete. If the `outgoing-body` is
-    /// dropped without calling `outgoing-body-finalize`, the implementation
+    /// dropped without calling `outgoing-body.finalize`, the implementation
     /// should treat the body as corrupted.
     finish: static func(this: outgoing-body, trailers: option<trailers>);
   }
@@ -200,12 +199,9 @@ interface types {
   /// the client can call `listen` to get a `pollable` that can be passed to
   /// `wasi:io/poll.poll-list`.
   resource future-incoming-response {
-    /// option indicates readiness.
-    /// outer result indicates you are allowed to get the
-    /// incoming-response-or-error at most once. subsequent calls after ready
-    /// will return an error here.
-    /// inner result indicates whether the incoming-response was available, or an
-    /// error occured.
+    /// The option indicates readiness. The outer result must return failure if `get`
+    /// is called after returning a non-empty result.  The inner result indicates whether
+    /// the incoming response successfully started.
     get: func() -> option<result<result<incoming-response, error>>>;
 
     subscribe: func() -> pollable;

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -65,22 +65,24 @@ interface types {
   type trailers = fields;
 
   /// The following block defines the `incoming-request` and `outgoing-request`
-  /// resource types that correspond to HTTP standard Requests. Soon, when
-  /// resource types are added, the `u32` type aliases can be replaced by
-  /// proper `resource` type definitions containing all the functions as
-  /// methods. Later, Preview2 will allow both types to be merged together into
-  /// a single `request` type (that uses the single `stream` type mentioned
-  /// above). The `consume` and `write` methods may only be called once (and
-  /// return failure thereafter).
+  /// resource types that correspond to HTTP standard Requests. Later, Preview3
+  /// will allow both types to be merged together into a single `request` type
+  /// (that uses the single `stream` type mentioned above). The `consume` and
+  /// `write` methods may only be called once (and return failure thereafter).
   resource incoming-request {
+    /// Returns the method of the incoming request.
     method: func() -> method;
 
+    /// Returns the path with query parameters from the request, as a string.
     path-with-query: func() -> option<string>;
 
+    /// Returns the protocol scheme from the request.
     scheme: func() -> option<scheme>;
 
+    /// Returns the authority from the request, if it was present.
     authority: func() -> option<string>;
 
+    /// Returns the headers from the request.
     headers: func() -> headers;
 
     /// Will return the incoming-body child at most once. If called more than
@@ -89,6 +91,7 @@ interface types {
   }
 
   resource outgoing-request {
+    /// Construct a new `outgoing-request`.
     constructor(
       method: method,
       path-with-query: option<string>,
@@ -123,6 +126,8 @@ interface types {
   /// an outparam goes away entirely (the `wasi:http/handler` interface used for
   /// both incoming and outgoing can simply return a `stream`).
   resource response-outparam {
+    /// Set the value of the `response-outparam` to indicate either a response,
+    /// or an error.
     set: static func(
       param: response-outparam,
       response: result<outgoing-response, error>,
@@ -139,8 +144,10 @@ interface types {
   /// mentioned above). The `consume` and `write` methods may only be called
   /// once (and return failure thereafter).
   resource incoming-response {
+    /// Returns the status code from the `incoming-response`.
     status: func() -> status-code;
 
+    /// Returns the headers from the `incoming-response`.
     headers: func() -> headers;
 
     /// May be called at most once. returns error if called additional times.
@@ -168,6 +175,7 @@ interface types {
   }
 
   resource outgoing-response {
+    /// Construct an `outgoing-response`.
     constructor(status-code: status-code, headers: borrow<headers>);
 
     /// Will give the child outgoing-response at most once. subsequent calls
@@ -199,6 +207,8 @@ interface types {
     /// indicates whether the incoming response successfully started.
     get: func() -> option<result<result<incoming-response, error>>>;
 
+    /// Pollable that resolves when the `get` method will resolve to a `Some`
+    /// result.
     subscribe: func() -> pollable;
   }
 }

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -1,11 +1,11 @@
-// The `wasi:http/types` interface is meant to be imported by components to
-// define the HTTP resource types and operations used by the component's
-// imported and exported interfaces.
+/// The `wasi:http/types` interface is meant to be imported by components to
+/// define the HTTP resource types and operations used by the component's
+/// imported and exported interfaces.
 interface types {
   use wasi:io/streams.{input-stream, output-stream};
   use wasi:io/poll.{pollable};
 
-  // This type corresponds to HTTP standard Methods.
+  /// This type corresponds to HTTP standard Methods.
   variant method {
     get,
     head,
@@ -19,16 +19,16 @@ interface types {
     other(string)
   }
 
-  // This type corresponds to HTTP standard Related Schemes.
+  /// This type corresponds to HTTP standard Related Schemes.
   variant scheme {
     HTTP,
     HTTPS,
     other(string)
   }
 
-  // TODO: perhaps better align with HTTP semantics?
-  // This type enumerates the different kinds of errors that may occur when
-  // initially returning a response.
+  /// TODO: perhaps better align with HTTP semantics?
+  /// This type enumerates the different kinds of errors that may occur when
+  /// initially returning a response.
   variant error {
     invalid-url(string),
     timeout-error(string),
@@ -36,44 +36,42 @@ interface types {
     unexpected-error(string)
   }
 
-  // This following block defines the `fields` resource which corresponds to
-  // HTTP standard Fields. Soon, when resource types are added, the `type
-  // fields = u32` type alias can be replaced by a proper `resource fields`
-  // definition containing all the functions using the method syntactic sugar.
+  /// This following block defines the `fields` resource which corresponds to
+  /// HTTP standard Fields.
   resource fields {
-    // Multiple values for a header are multiple entries in the list with the
-    // same key.
+    /// Multiple values for a header are multiple entries in the list with the
+    /// same key.
     constructor(entries: list<tuple<string,list<u8>>>);
 
-    // Values off wire are not necessarily well formed, so they are given by
-    // list<u8> instead of string.
+    /// Values off wire are not necessarily well formed, so they are given by
+    /// list<u8> instead of string.
     get: func(name: string) -> list<list<u8>>;
 
-    // Values off wire are not necessarily well formed, so they are given by
-    // list<u8> instead of string.
+    /// Values off wire are not necessarily well formed, so they are given by
+    /// list<u8> instead of string.
     set: func(name: string, value: list<list<u8>>);
     delete: func(name: string);
     append: func(name: string, value: list<u8>);
 
-    // Values off wire are not necessarily well formed, so they are given by
-    // list<u8> instead of string.
+    /// Values off wire are not necessarily well formed, so they are given by
+    /// list<u8> instead of string.
     entries: func() -> list<tuple<string,list<u8>>>;
 
-    // Deep copy of all contents in a fields.
+    /// Deep copy of all contents in a fields.
     clone: func() -> fields;
   }
 
   type headers = fields;
   type trailers = fields;
 
-  // The following block defines the `incoming-request` and `outgoing-request`
-  // resource types that correspond to HTTP standard Requests. Soon, when
-  // resource types are added, the `u32` type aliases can be replaced by
-  // proper `resource` type definitions containing all the functions as
-  // methods. Later, Preview2 will allow both types to be merged together into
-  // a single `request` type (that uses the single `stream` type mentioned
-  // above). The `consume` and `write` methods may only be called once (and
-  // return failure thereafter).
+  /// The following block defines the `incoming-request` and `outgoing-request`
+  /// resource types that correspond to HTTP standard Requests. Soon, when
+  /// resource types are added, the `u32` type aliases can be replaced by
+  /// proper `resource` type definitions containing all the functions as
+  /// methods. Later, Preview2 will allow both types to be merged together into
+  /// a single `request` type (that uses the single `stream` type mentioned
+  /// above). The `consume` and `write` methods may only be called once (and
+  /// return failure thereafter).
   resource incoming-request {
     method: func() -> method;
 
@@ -85,8 +83,8 @@ interface types {
 
     headers: func() -> headers;
 
-    // Will return the incoming-body child at most once. If called more than
-    // once, subsequent calls will return error.
+    /// Will return the incoming-body child at most once. If called more than
+    /// once, subsequent calls will return error.
     consume: func() -> result<incoming-body>;
   }
 
@@ -99,67 +97,61 @@ interface types {
       headers: borrow<headers>
     );
 
-    // Will return the outgoing-body child at most once. If called more than
-    // once, subsequent calls will return error.
+    /// Will return the outgoing-body child at most once. If called more than
+    /// once, subsequent calls will return error.
     write: func() -> result<outgoing-body>;
   }
 
-  // Additional optional parameters that can be set when making a request.
+  /// Additional optional parameters that can be set when making a request.
   record request-options {
-    // The following timeouts are specific to the HTTP protocol and work
-    // independently of the overall timeouts passed to `io.poll.poll-list`.
+    /// The following timeouts are specific to the HTTP protocol and work
+    /// independently of the overall timeouts passed to `io.poll.poll-list`.
 
-    // The timeout for the initial connect.
+    /// The timeout for the initial connect.
     connect-timeout-ms: option<u32>,
 
-    // The timeout for receiving the first byte of the response body.
+    /// The timeout for receiving the first byte of the response body.
     first-byte-timeout-ms: option<u32>,
 
-    // The timeout for receiving the next chunk of bytes in the response body
-    // stream.
+    /// The timeout for receiving the next chunk of bytes in the response body
+    /// stream.
     between-bytes-timeout-ms: option<u32>
   }
 
-  // The following block defines a special resource type used by the
-  // `wasi:http/incoming-handler` interface. When resource types are added, this
-  // block can be replaced by a proper `resource response-outparam { ... }`
-  // definition. Later, with Preview3, the need for an outparam goes away entirely
-  // (the `wasi:http/handler` interface used for both incoming and outgoing can
-  // simply return a `stream`).
+  /// The following block defines a special resource type used by the
+  /// `wasi:http/incoming-handler` interface. Later, with Preview3, the need for
+  /// an outparam goes away entirely (the `wasi:http/handler` interface used for
+  /// both incoming and outgoing can simply return a `stream`).
   resource response-outparam {
     set: static func(param: response-outparam, response: result<outgoing-response, error>);
   }
 
-  // This type corresponds to the HTTP standard Status Code.
+  /// This type corresponds to the HTTP standard Status Code.
   type status-code = u16;
 
-  // The following block defines the `incoming-response` and `outgoing-response`
-  // resource types that correspond to HTTP standard Responses. Soon, when
-  // resource types are added, the `u32` type aliases can be replaced by proper
-  // `resource` type definitions containing all the functions as methods. Later,
-  // Preview2 will allow both types to be merged together into a single `response`
-  // type (that uses the single `stream` type mentioned above). The `consume` and
-  // `write` methods may only be called once (and return failure thereafter).
+  /// The following block defines the `incoming-response` and `outgoing-response`
+  /// resource types that correspond to HTTP standard Responses. Later, Preview3
+  /// will allow both types to be merged together into a single `response` type
+  /// (that uses the single `stream` type mentioned above). The `consume` and
+  /// `write` methods may only be called once (and return failure thereafter).
   resource incoming-response {
     status: func() -> status-code;
 
     headers: func() -> headers;
 
-    // May be called at most once. returns error if called additional times.
-    // TODO: make incoming-request-consume work the same way, giving a child
-    // incoming-body.
+    /// May be called at most once. returns error if called additional times.
     consume: func() -> result<incoming-body>;
   }
 
   resource incoming-body {
-    // returned input-stream is a child - the implementation may trap if
-    // incoming-body is dropped (or consumed by call to
-    // incoming-body.finish) before the input-stream is dropped.
-    // May be called at most once. Returns error if called additional times.
+    /// returned input-stream is a child - the implementation may trap if
+    /// incoming-body is dropped (or consumed by call to
+    /// incoming-body.finish) before the input-stream is dropped.
+    /// May be called at most once. Returns error if called additional times.
     %stream: func() -> result<input-stream>;
 
-    // Takes ownership of incoming-body and will trap if the
-    // input-stream child is still alive.
+    /// Takes ownership of incoming-body and will trap if the
+    /// input-stream child is still alive.
     finish: static func(this: incoming-body) -> future-trailers;
   }
 

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -4,7 +4,7 @@
 interface types {
   use wasi:io/streams.{input-stream, output-stream};
   use wasi:io/poll.{pollable};
-  
+
   // This type corresponds to HTTP standard Methods.
   variant method {
     get,
@@ -30,101 +30,84 @@ interface types {
   // This type enumerates the different kinds of errors that may occur when
   // initially returning a response.
   variant error {
-      invalid-url(string),
-      timeout-error(string),
-      protocol-error(string),
-      unexpected-error(string)
+    invalid-url(string),
+    timeout-error(string),
+    protocol-error(string),
+    unexpected-error(string)
   }
 
   // This following block defines the `fields` resource which corresponds to
   // HTTP standard Fields. Soon, when resource types are added, the `type
   // fields = u32` type alias can be replaced by a proper `resource fields`
   // definition containing all the functions using the method syntactic sugar.
-  type fields = u32;
-  drop-fields: func(fields: fields);
-  new-fields: func(entries: list<tuple<string,list<u8>>>) -> fields;
-  // Returns an empty list if `name` is not present.
-  fields-get: func(fields: fields, name: string) -> list<list<u8>>;
-  fields-set: func(fields: fields, name: string, value: list<list<u8>>);
-  fields-delete: func(fields: fields, name: string);
-  fields-append: func(fields: fields, name: string, value: list<u8>);
-  fields-entries: func(fields: fields) -> list<tuple<string,list<u8>>>;
-  fields-clone: func(fields: fields) -> fields;
+  resource fields {
+    // Multiple values for a header are multiple entries in the list with the
+    // same key.
+    constructor(entries: list<tuple<string,list<u8>>>);
+
+    // Values off wire are not necessarily well formed, so they are given by
+    // list<u8> instead of string.
+    get: func(name: string) -> list<list<u8>>;
+
+    // Values off wire are not necessarily well formed, so they are given by
+    // list<u8> instead of string.
+    set: func(name: string, value: list<list<u8>>);
+    delete: func(name: string);
+    append: func(name: string, value: list<u8>);
+
+    // Values off wire are not necessarily well formed, so they are given by
+    // list<u8> instead of string.
+    entries: func() -> list<tuple<string,list<u8>>>;
+
+    // Deep copy of all contents in a fields.
+    clone: func() -> fields;
+  }
 
   type headers = fields;
   type trailers = fields;
 
-  // The following block defines stream types which corresponds to the HTTP
-  // standard Contents and Trailers. With Preview3, all of these fields can be
-  // replaced by a stream<u8, option<trailers>>. In the interim, we need to
-  // build on separate resource types defined by `wasi:io/streams`. The
-  // `finish-` functions emulate the stream's result value and MUST be called
-  // exactly once after the final read/write from/to the stream before dropping
-  // the stream. The optional `future-` types describe the asynchronous result of
-  // reading/writing the optional HTTP trailers and MUST be waited on and dropped
-  // to complete streaming the request/response.
-  type incoming-stream = input-stream;
-  type outgoing-stream = output-stream;
-  finish-incoming-stream: func(s: incoming-stream) -> option<future-trailers>;
-  finish-outgoing-stream: func(s: outgoing-stream);
-  finish-outgoing-stream-with-trailers: func(s: outgoing-stream, trailers: trailers) -> future-write-trailers-result;
-
-  // The following block defines the `future-trailers` resource, which is
-  // returned when finishing an `incoming-stream` to asychronously produce the
-  // final trailers.
-  type future-trailers = u32;
-  drop-future-trailers: func(f: future-trailers);
-  future-trailers-get: func(f: future-trailers) -> option<result<trailers, error>>;
-  listen-to-future-trailers: func(f: future-trailers) -> pollable;
-
-  // The following block defines the `future-write-trailers-result` resource,
-  // which is returned when finishing an `outgoing-stream` and asychronously
-  // indicates the success or failure of writing the trailers.
-  type future-write-trailers-result = u32;
-  drop-future-write-trailers-result: func(f: future-write-trailers-result);
-  future-write-trailers-result-get: func(f: future-write-trailers-result) -> option<result<_, error>>;
-  listen-to-future-write-trailers-result: func(f: future-write-trailers-result) -> pollable;
-
   // The following block defines the `incoming-request` and `outgoing-request`
   // resource types that correspond to HTTP standard Requests. Soon, when
-  // resource types are added, the `u32` type aliases can be replaced by proper
-  // `resource` type definitions containing all the functions as methods.
-  // Later, Preview2 will allow both types to be merged together into a single
-  // `request` type (that uses the single `stream` type mentioned above). The
-  // `consume` and `write` methods may only be called once (and return failure
-  // thereafter). The `headers` and `trailers` passed into and out of requests
-  // are shared with the request, with all mutations visible to all uses.
-  // Components MUST avoid updating `headers` and `trailers` after passing a
-  // request that points to them to the outside world.
-  // The streams returned by `consume` and `write` are owned by the request and
-  // response objects. The streams are destroyed when the request/response is
-  // dropped, thus a client MUST drop any handle referring to a request/response stream
-  // before dropping the request/response or passing ownership of the request/response
-  // to the outside world. The caller can also call drop on the stream before the 
-  // request/response is dropped if they want to release resources earlier.
-  type incoming-request = u32;
-  type outgoing-request = u32;
-  drop-incoming-request: func(request: incoming-request);
-  drop-outgoing-request: func(request: outgoing-request);
-  incoming-request-method: func(request: incoming-request) -> method;
-  incoming-request-path-with-query: func(request: incoming-request) -> option<string>;
-  incoming-request-scheme: func(request: incoming-request) -> option<scheme>;
-  incoming-request-authority: func(request: incoming-request) -> option<string>;
-  incoming-request-headers: func(request: incoming-request) -> headers;
-  incoming-request-consume: func(request: incoming-request) -> result<incoming-stream>;
-  new-outgoing-request: func(
-    method: method,
-    path-with-query: option<string>,
-    scheme: option<scheme>,
-    authority: option<string>,
-    headers: headers
-  ) -> result<outgoing-request, error>;
-  outgoing-request-write: func(request: outgoing-request) -> result<outgoing-stream>;
+  // resource types are added, the `u32` type aliases can be replaced by
+  // proper `resource` type definitions containing all the functions as
+  // methods. Later, Preview2 will allow both types to be merged together into
+  // a single `request` type (that uses the single `stream` type mentioned
+  // above). The `consume` and `write` methods may only be called once (and
+  // return failure thereafter).
+  resource incoming-request {
+    method: func() -> method;
+
+    path-with-query: func() -> option<string>;
+
+    scheme: func() -> option<scheme>;
+
+    authority: func() -> option<string>;
+
+    headers: func() -> headers;
+
+    // Will return the incoming-body child at most once. If called more than
+    // once, subsequent calls will return error.
+    consume: func() -> result<incoming-body>;
+  }
+
+  resource outgoing-request {
+    constructor(
+      method: method,
+      path-with-query: option<string>,
+      scheme: option<scheme>,
+      authority: option<string>,
+      headers: borrow<headers>
+    );
+
+    // Will return the outgoing-body child at most once. If called more than
+    // once, subsequent calls will return error.
+    write: func() -> result<outgoing-body>;
+  }
 
   // Additional optional parameters that can be set when making a request.
   record request-options {
     // The following timeouts are specific to the HTTP protocol and work
-    // independently of the overall timeouts passed to `io.poll.poll-oneoff`.
+    // independently of the overall timeouts passed to `io.poll.poll-list`.
 
     // The timeout for the initial connect.
     connect-timeout-ms: option<u32>,
@@ -143,9 +126,9 @@ interface types {
   // definition. Later, with Preview3, the need for an outparam goes away entirely
   // (the `wasi:http/handler` interface used for both incoming and outgoing can
   // simply return a `stream`).
-  type response-outparam = u32;
-  drop-response-outparam: func(response: response-outparam);
-  set-response-outparam: func(param: response-outparam, response: result<outgoing-response, error>) -> result;
+  resource response-outparam {
+    set: static func(param: response-outparam, response: result<outgoing-response, error>);
+  }
 
   // This type corresponds to the HTTP standard Status Code.
   type status-code = u16;
@@ -157,32 +140,74 @@ interface types {
   // Preview2 will allow both types to be merged together into a single `response`
   // type (that uses the single `stream` type mentioned above). The `consume` and
   // `write` methods may only be called once (and return failure thereafter).
-  // The `headers` and `trailers` passed into and out of responses are shared
-  // with the response, with all mutations visible to all uses. Components MUST
-  // avoid updating `headers` and `trailers` after passing a response that
-  // points to them to the outside world.
-  type incoming-response = u32;
-  type outgoing-response = u32;
-  drop-incoming-response: func(response: incoming-response);
-  drop-outgoing-response: func(response: outgoing-response);
-  incoming-response-status: func(response: incoming-response) -> status-code;
-  incoming-response-headers: func(response: incoming-response) -> headers;
-  incoming-response-consume: func(response: incoming-response) -> result<incoming-stream>;
-  new-outgoing-response: func(
-    status-code: status-code,
-    headers: headers
-  ) -> result<outgoing-response, error>;
-  outgoing-response-write: func(response: outgoing-response) -> result<outgoing-stream>;
+  resource incoming-response {
+    status: func() -> status-code;
 
-  // The following block defines a special resource type used by the
-  // `wasi:http/outgoing-handler` interface to emulate
-  // `future<result<response, error>>` in advance of Preview3. Given a
-  // `future-incoming-response`, the client can call the non-blocking `get`
-  // method to get the result if it is available. If the result is not available,
-  // the client can call `listen` to get a `pollable` that can be passed to
-  // `io.poll.poll-oneoff`.
-  type future-incoming-response = u32;
-  drop-future-incoming-response: func(f: future-incoming-response);
-  future-incoming-response-get: func(f: future-incoming-response) -> option<result<incoming-response, error>>;
-  listen-to-future-incoming-response: func(f: future-incoming-response) -> pollable;
+    headers: func() -> headers;
+
+    // May be called at most once. returns error if called additional times.
+    // TODO: make incoming-request-consume work the same way, giving a child
+    // incoming-body.
+    consume: func() -> result<incoming-body>;
+  }
+
+  resource incoming-body {
+    // returned input-stream is a child - the implementation may trap if
+    // incoming-body is dropped (or consumed by call to
+    // incoming-body-finish) before the input-stream is dropped.
+    // May be called at most once. returns error if called additional times.
+    %stream: func() -> result<input-stream>;
+
+    // takes ownership of incoming-body. this will trap if the
+    // incoming-body-stream child is still alive!
+    finish: static func(this: incoming-body) -> future-trailers;
+  }
+
+  resource future-trailers {
+    /// Pollable that resolves when the body has been fully read, and the trailers
+    /// are ready to be consumed.
+    subscribe: func() -> pollable;
+
+    /// Retrieve reference to trailers, if they are ready.
+    get: func() -> option<result<trailers, error>>;
+  }
+
+  resource outgoing-response {
+    constructor(status-code: status-code, headers: borrow<headers>);
+
+    /// Will give the child outgoing-response at most once. subsequent calls will
+    /// return an error.
+    write: func() -> result<outgoing-body>;
+  }
+
+  resource outgoing-body {
+    /// Will give the child output-stream at most once. subsequent calls will
+    /// return an error.
+    write: func() -> result<output-stream>;
+
+    /// Finalize an outgoing body, optionally providing trailers. This must be
+    /// called to signal that the response is complete. If the `outgoing-body` is
+    /// dropped without calling `outgoing-body-finalize`, the implementation
+    /// should treat the body as corrupted.
+    finish: static func(this: outgoing-body, trailers: option<trailers>);
+  }
+
+  /// The following block defines a special resource type used by the
+  /// `wasi:http/outgoing-handler` interface to emulate
+  /// `future<result<response, error>>` in advance of Preview3. Given a
+  /// `future-incoming-response`, the client can call the non-blocking `get`
+  /// method to get the result if it is available. If the result is not available,
+  /// the client can call `listen` to get a `pollable` that can be passed to
+  /// `wasi:io/poll.poll-list`.
+  resource future-incoming-response {
+    /// option indicates readiness.
+    /// outer result indicates you are allowed to get the
+    /// incoming-response-or-error at most once. subsequent calls after ready
+    /// will return an error here.
+    /// inner result indicates whether the incoming-response was available, or an
+    /// error occured.
+    get: func() -> option<result<result<incoming-response, error>>>;
+
+    subscribe: func() -> pollable;
+  }
 }

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -123,17 +123,21 @@ interface types {
   /// an outparam goes away entirely (the `wasi:http/handler` interface used for
   /// both incoming and outgoing can simply return a `stream`).
   resource response-outparam {
-    set: static func(param: response-outparam, response: result<outgoing-response, error>);
+    set: static func(
+      param: response-outparam,
+      response: result<outgoing-response, error>,
+    );
   }
 
   /// This type corresponds to the HTTP standard Status Code.
   type status-code = u16;
 
-  /// The following block defines the `incoming-response` and `outgoing-response`
-  /// resource types that correspond to HTTP standard Responses. Later, Preview3
-  /// will allow both types to be merged together into a single `response` type
-  /// (that uses the single `stream` type mentioned above). The `consume` and
-  /// `write` methods may only be called once (and return failure thereafter).
+  /// The following block defines the `incoming-response` and
+  /// `outgoing-response` resource types that correspond to HTTP standard
+  /// Responses. Later, Preview3 will allow both types to be merged together
+  /// into a single `response` type (that uses the single `stream` type
+  /// mentioned above). The `consume` and `write` methods may only be called
+  /// once (and return failure thereafter).
   resource incoming-response {
     status: func() -> status-code;
 
@@ -166,8 +170,8 @@ interface types {
   resource outgoing-response {
     constructor(status-code: status-code, headers: borrow<headers>);
 
-    /// Will give the child outgoing-response at most once. subsequent calls will
-    /// return an error.
+    /// Will give the child outgoing-response at most once. subsequent calls
+    /// will return an error.
     write: func() -> result<outgoing-body>;
   }
 
@@ -177,23 +181,22 @@ interface types {
     write: func() -> result<output-stream>;
 
     /// Finalize an outgoing body, optionally providing trailers. This must be
-    /// called to signal that the response is complete. If the `outgoing-body` is
-    /// dropped without calling `outgoing-body.finalize`, the implementation
+    /// called to signal that the response is complete. If the `outgoing-body`
+    /// is dropped without calling `outgoing-body.finalize`, the implementation
     /// should treat the body as corrupted.
     finish: static func(this: outgoing-body, trailers: option<trailers>);
   }
 
   /// The following block defines a special resource type used by the
-  /// `wasi:http/outgoing-handler` interface to emulate
-  /// `future<result<response, error>>` in advance of Preview3. Given a
-  /// `future-incoming-response`, the client can call the non-blocking `get`
-  /// method to get the result if it is available. If the result is not available,
-  /// the client can call `listen` to get a `pollable` that can be passed to
-  /// `wasi:io/poll.poll-list`.
+  /// `wasi:http/outgoing-handler` interface to emulate `future<result<response,
+  /// error>>` in advance of Preview3. Given a `future-incoming-response`, the
+  /// client can call the non-blocking `get` method to get the result if it is
+  /// available. If the result is not available, the client can call `listen` to
+  /// get a `pollable` that can be passed to `wasi:io/poll.poll-list`.
   resource future-incoming-response {
-    /// The option indicates readiness. The outer result must return failure if `get`
-    /// is called after returning a non-empty result.  The inner result indicates whether
-    /// the incoming response successfully started.
+    /// The option indicates readiness. The outer result must return failure if
+    /// `get` is called after returning a non-empty result.  The inner result
+    /// indicates whether the incoming response successfully started.
     get: func() -> option<result<result<incoming-response, error>>>;
 
     subscribe: func() -> pollable;


### PR DESCRIPTION
Convert all pseudo-resources to full resources, and as such introduces some `borrow<..>` annotations.

Additionally, this reworks body handling to go through an intermediate resource, rather than expose direct access to the underlying stream for the request/response resource. This intermediate resource allows us to better track when trailers are expected to be written or read.