### PR TITLE
Rename the methods to retrieve `outgoing-body` from `write` to `body`

### DIFF
--- a/proxy.md
+++ b/proxy.md
@@ -884,16 +884,19 @@ return success at most once, and subsequent calls will return error.</p>
 <ul>
 <li><a name="constructor_outgoing_request.0"></a> own&lt;<a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a>&gt;</li>
 </ul>
-<h4><a name="method_outgoing_request.write"><code>[method]outgoing-request.write: func</code></a></h4>
-<p>Will return the outgoing-body child at most once. If called more than
-once, subsequent calls will return error.</p>
+<h4><a name="method_outgoing_request.body"><code>[method]outgoing-request.body: func</code></a></h4>
+<p>Returns the resource corresponding to the outgoing Body for this
+Request.</p>
+<p>Returns success on the first call: the <a href="#outgoing_body"><code>outgoing-body</code></a> resource for
+this <a href="#outgoing_response"><code>outgoing-response</code></a> can be retrieved at most once. Subsequent
+calls will return error.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="method_outgoing_request.write.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a>&gt;</li>
+<li><a name="method_outgoing_request.body.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_outgoing_request.write.0"></a> result&lt;own&lt;<a href="#outgoing_body"><a href="#outgoing_body"><code>outgoing-body</code></a></a>&gt;&gt;</li>
+<li><a name="method_outgoing_request.body.0"></a> result&lt;own&lt;<a href="#outgoing_body"><a href="#outgoing_body"><code>outgoing-body</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="static_response_outparam.set"><code>[static]response-outparam.set: func</code></a></h4>
 <p>Set the value of the <a href="#response_outparam"><code>response-outparam</code></a> to either send a response,
@@ -1008,19 +1011,18 @@ occured receiving them.</p>
 <ul>
 <li><a name="constructor_outgoing_response.0"></a> own&lt;<a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a>&gt;</li>
 </ul>
-<h4><a name="method_outgoing_response.write"><code>[method]outgoing-response.write: func</code></a></h4>
+<h4><a name="method_outgoing_response.body"><code>[method]outgoing-response.body: func</code></a></h4>
 <p>Returns the resource corresponding to the outgoing Body for this Response.</p>
 <p>Returns success on the first call: the <a href="#outgoing_body"><code>outgoing-body</code></a> resource for
-this <a href="#outgoing_response"><code>outgoing-response</code></a> can be retrieved at most once. Sunsequent
+this <a href="#outgoing_response"><code>outgoing-response</code></a> can be retrieved at most once. Subsequent
 calls will return error.</p>
-<p>FIXME: rename this method to <code>body</code>.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="method_outgoing_response.write.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a>&gt;</li>
+<li><a name="method_outgoing_response.body.self"><code>self</code></a>: borrow&lt;<a href="#outgoing_response"><a href="#outgoing_response"><code>outgoing-response</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_outgoing_response.write.0"></a> result&lt;own&lt;<a href="#outgoing_body"><a href="#outgoing_body"><code>outgoing-body</code></a></a>&gt;&gt;</li>
+<li><a name="method_outgoing_response.body.0"></a> result&lt;own&lt;<a href="#outgoing_body"><a href="#outgoing_body"><code>outgoing-body</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="method_outgoing_body.write"><code>[method]outgoing-body.write: func</code></a></h4>
 <p>Returns a stream for writing the body contents.</p>

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -135,9 +135,13 @@ interface types {
       headers: borrow<headers>
     );
 
-    /// Will return the outgoing-body child at most once. If called more than
-    /// once, subsequent calls will return error.
-    write: func() -> result<outgoing-body>;
+    /// Returns the resource corresponding to the outgoing Body for this
+    /// Request.
+    ///
+    /// Returns success on the first call: the `outgoing-body` resource for
+    /// this `outgoing-response` can be retrieved at most once. Subsequent
+    /// calls will return error.
+    body: func() -> result<outgoing-body>;
   }
 
   /// Parameters for making an HTTP Request. Each of these parameters is an
@@ -264,11 +268,9 @@ interface types {
     /// Returns the resource corresponding to the outgoing Body for this Response.
     ///
     /// Returns success on the first call: the `outgoing-body` resource for
-    /// this `outgoing-response` can be retrieved at most once. Sunsequent
+    /// this `outgoing-response` can be retrieved at most once. Subsequent
     /// calls will return error.
-    ///
-    /// FIXME: rename this method to `body`.
-    write: func() -> result<outgoing-body>;
+    body: func() -> result<outgoing-body>;
   }
 
   /// Represents an outgoing HTTP Request or Response's Body.


### PR DESCRIPTION
Prior to this PR, the `outgoing-request` and `outgoing-response` resources have methods `write` which return `result<outgoing-body>`.

`body` is a better name than `write` - it makes it explicit this is about access to a body resource. The `outgoing-body` resource itself has a method `write` which gives the body contents as a stream. Using different names for these closely related but different methods makes their distinction more clear.

Additionally: the docs for `outgoing-request.write` were incorrect - the returned `outgoing-body` is not a child of the `outgoing-request` (or `outgoing-response`). If we were to enforce a child relationship here, outgoing body streaming (i.e. writing to the body after the request or response has been initiated) would not be possible. The word `child` had been left in the docs by accident, and this PR removes it and makes the docs for both `body` methods the same.