### PR TITLE
Change the portability criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,10 @@ wasi-http is currently in [Phase 2](https://github.com/WebAssembly/WASI/blob/mai
 * David Justice
 * Luke Wagner
 
-### Phase 4 Advancement Criteria
+### Portability Criteria for Phase 4
 
-WASI-http must have at least two complete independent implementations. One
-implementation must execute in a browser and may be implemented in terms of the
-[Fetch API] using JavaScript. The other implementation must be implemented
-in a non-browser WebAssembly runtime and demonstrate embeddability in a
-Web server.
-
-[Fetch API]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+WASI-http must have at least two complete independent implementations
+demonstrating embeddability in a production HTTP server context.
 
 ### Introduction
 


### PR DESCRIPTION
As discussed in today's WASI Subgroup meeting, based on @guybedford's presentation, a meaningful second implementation of this proposal (beyond a pure-wasm runtime like Wasmtime and WasmEdge) would be Node.js (or Deno or Bun), running a `wasi:http/proxy`-targeting component directly, implemented in terms of their existing C++ HTTP implementations.  In the short-term, this embedding can be implemented via JS glue code (leveraging [jco transpile](https://github.com/bytecodealliance/jco#transpile) and calling existing Node-compatible APIs), but a more-optimized C++ native binding could be transparently swapped in in the future as motivated by usage and performance from Preview 2 feedback.

Rather than just fixing "Node and Node-compatible runtime" in the Portability Criteria, this PR does what other proposals have done and just says "two independent production HTTP servers".  Happy to discuss more and poll on this in the next WASI subgroup meeting ([WASI-11-16](https://github.com/WebAssembly/meetings/blob/main/wasi/2023/WASI-11-16.md)).