### PR TITLE
docs: fix language for portability criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ wasi-http is currently in [Phase 2](https://github.com/WebAssembly/WASI/blob/mai
 * David Justice
 * Luke Wagner
 
-### Portability Criteria for Phase 4
+### Portability Criteria
 
 WASI-http must have at least two complete independent implementations
 demonstrating embeddability in a production HTTP server context.


### PR DESCRIPTION
This is to align language in the WASI phase process with all pre-existing WASI repos.

We're aligning the header text across repos, and we've opted to remove the phase 4 mention to keep proposals consistent.