### PR TITLE
feat: introduce `outgoing-request.into-incoming-request`

### DIFF
--- a/proxy.md
+++ b/proxy.md
@@ -1032,6 +1032,18 @@ another component by e.g. <code>outgoing-handler.handle</code>.</p>
 <ul>
 <li><a name="method_outgoing_request.headers.0"></a> own&lt;<a href="#headers"><a href="#headers"><code>headers</code></a></a>&gt;</li>
 </ul>
+<h4><a name="static_outgoing_request.into_incoming_request"><code>[static]outgoing-request.into-incoming-request: func</code></a></h4>
+<p>Takes ownership of <a href="#outgoing_request"><code>outgoing-request</code></a>, and returns an <a href="#incoming_request"><code>incoming-request</code></a>.
+This allows guests to invoke <code>incoming-handler.handle</code> on other components.
+This function will trap if the <a href="#headers"><code>headers</code></a> child is still alive.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="static_outgoing_request.into_incoming_request.this"><code>this</code></a>: own&lt;<a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a>&gt;</li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="static_outgoing_request.into_incoming_request.0"></a> own&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
+</ul>
 <h4><a name="constructor_request_options"><code>[constructor]request-options: func</code></a></h4>
 <p>Construct a default <a href="#request_options"><code>request-options</code></a> value.</p>
 <h5>Return values</h5>

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -306,6 +306,11 @@ interface types {
     /// `outgoing-request` is dropped, or its ownership is transfered to
     /// another component by e.g. `outgoing-handler.handle`.
     headers: func() -> headers;
+
+    /// Takes ownership of `outgoing-request`, and returns an `incoming-request`.
+    /// This allows guests to invoke `incoming-handler.handle` on other components.
+    /// This function will trap if the `headers` child is still alive.
+    into-incoming-request: static func(this: outgoing-request) -> incoming-request;
   }
 
   /// Parameters for making an HTTP Request. Each of these parameters is


### PR DESCRIPTION
Closes #89 

I wish there was a nicer way to handle this, but I am not sure what it could look like at the moment.

This does not support body streaming in a single-threaded context, but at least it allows for invoking `incoming-handler.handle`