### PR TITLE
Add `fields.has` 

### DIFF
--- a/proxy.md
+++ b/proxy.md
@@ -745,7 +745,10 @@ syntactically invalid, or if a header was forbidden.</p>
 <li><a name="static_fields.from_list.0"></a> result&lt;own&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;, <a href="#header_error"><a href="#header_error"><code>header-error</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_fields.get"><code>[method]fields.get: func</code></a></h4>
-<p>Get all of the values corresponding to a key.</p>
+<p>Get all of the values corresponding to a key. If the key is not present
+in this <a href="#fields"><code>fields</code></a>, an empty list is returned. However, if the key is
+present but empty, this is represented by a list with one or more
+empty field-values present.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_fields.get.self"><code>self</code></a>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
@@ -754,6 +757,18 @@ syntactically invalid, or if a header was forbidden.</p>
 <h5>Return values</h5>
 <ul>
 <li><a name="method_fields.get.0"></a> list&lt;<a href="#field_value"><a href="#field_value"><code>field-value</code></a></a>&gt;</li>
+</ul>
+<h4><a name="method_fields.has"><code>[method]fields.has: func</code></a></h4>
+<p>Returns <code>true</code> when the key is present in this <a href="#fields"><code>fields</code></a>. If the key is
+syntactically invalid, <code>false</code> is returned.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="method_fields.has.self"><code>self</code></a>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>
+<li><a name="method_fields.has.name"><code>name</code></a>: <a href="#field_key"><a href="#field_key"><code>field-key</code></a></a></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="method_fields.has.0"></a> <code>bool</code></li>
 </ul>
 <h4><a name="method_fields.set"><code>[method]fields.set: func</code></a></h4>
 <p>Set all of the values for a key. Clears any existing values for that

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -169,10 +169,12 @@ interface types {
       entries: list<tuple<field-key,field-value>>
     ) -> result<fields, header-error>;
 
-    /// Get all of the values corresponding to a key. Returns a `none` value
-    /// when the key isn't present, to distinguish from the case where it's
-    /// present but empty.
-    get: func(name: field-key) -> option<list<field-value>>;
+    /// Get all of the values corresponding to a key.
+    get: func(name: field-key) -> list<field-value>;
+
+    /// Returns `true` when the key is present in this `fields`. If the key is
+    /// syntactically invalid, `false` is returned.
+    has: func(name: field-key) -> bool;
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -169,7 +169,10 @@ interface types {
       entries: list<tuple<field-key,field-value>>
     ) -> result<fields, header-error>;
 
-    /// Get all of the values corresponding to a key.
+    /// Get all of the values corresponding to a key. If the key is not present
+    /// in this `fields`, an empty list is returned. However, if the key is
+    /// present but empty, this is represented by a list with one more more
+    /// empty field-values present.
     get: func(name: field-key) -> list<field-value>;
 
     /// Returns `true` when the key is present in this `fields`. If the key is

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -169,8 +169,10 @@ interface types {
       entries: list<tuple<field-key,field-value>>
     ) -> result<fields, header-error>;
 
-    /// Get all of the values corresponding to a key.
-    get: func(name: field-key) -> list<field-value>;
+    /// Get all of the values corresponding to a key. Returns a `none` value
+    /// when the key isn't present, to distinguish from the case where it's
+    /// present but empty.
+    get: func(name: field-key) -> option<list<field-value>>;
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -171,7 +171,7 @@ interface types {
 
     /// Get all of the values corresponding to a key. If the key is not present
     /// in this `fields`, an empty list is returned. However, if the key is
-    /// present but empty, this is represented by a list with one more more
+    /// present but empty, this is represented by a list with one or more
     /// empty field-values present.
     get: func(name: field-key) -> list<field-value>;
 


### PR DESCRIPTION
It's not currently possible to test whether a `field-key` is present in a `fields`, as our return value of an empty list could mean either that the header was missing, or had no value. Add the `fields.has` method to give an unambiguous way to test for `field-key` presence in a `fields`.

Fixes #82 
