### PR TITLE
[0.3.0-draft] add `body.empty` static function

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -240,6 +240,9 @@ interface types {
       trailers: option<future<trailers>>
     );
 
+    /// Construct a new `body` with an empty stream and no trailers.
+    empty: static func() -> body;
+
     /// Returns the contents of the body, as a stream of bytes.
     ///
     /// This function may be called multiple times as long as any `stream`s


### PR DESCRIPTION
This is useful for creating empty bodies, e.g. when sending GET requests. It avoids the extra ceremony of creating a stream and immediately dropping the writable handle.