### PR TITLE
[0.3.0-draft] return previous values from `fields.delete`

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -195,8 +195,10 @@ interface types {
     /// Delete all values for a key. Does nothing if no values for the key
     /// exist.
     ///
+    /// Returns any values previously corresponding to the key.
+    ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
-    delete: func(name: field-key) -> result<_, header-error>;
+    delete: func(name: field-key) -> result<list<field-value>, header-error>;
 
     /// Append a value for a key. Does not change or delete any existing
     /// values for that key.


### PR DESCRIPTION
This saves the user from having to use `get` followed by `delete` if they want access to the values they're removing.