### PR TITLE
Change `wasi:clocks` from `include` to `import` in `wasi:http/proxy`

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -4,19 +4,172 @@ It is intended to be <code>include</code>d in other worlds.</p>
 <ul>
 <li>Imports:
 <ul>
+<li>interface <a href="#wasi_io_poll_0_2_0"><code>wasi:io/poll@0.2.0</code></a></li>
+<li>interface <a href="#wasi_clocks_monotonic_clock_0_2_0"><code>wasi:clocks/monotonic-clock@0.2.0</code></a></li>
+<li>interface <a href="#wasi_clocks_wall_clock_0_2_0"><code>wasi:clocks/wall-clock@0.2.0</code></a></li>
 <li>interface <a href="#wasi_random_random_0_2_0"><code>wasi:random/random@0.2.0</code></a></li>
 <li>interface <a href="#wasi_io_error_0_2_0"><code>wasi:io/error@0.2.0</code></a></li>
-<li>interface <a href="#wasi_io_poll_0_2_0"><code>wasi:io/poll@0.2.0</code></a></li>
 <li>interface <a href="#wasi_io_streams_0_2_0"><code>wasi:io/streams@0.2.0</code></a></li>
 <li>interface <a href="#wasi_cli_stdout_0_2_0"><code>wasi:cli/stdout@0.2.0</code></a></li>
 <li>interface <a href="#wasi_cli_stderr_0_2_0"><code>wasi:cli/stderr@0.2.0</code></a></li>
 <li>interface <a href="#wasi_cli_stdin_0_2_0"><code>wasi:cli/stdin@0.2.0</code></a></li>
-<li>interface <a href="#wasi_clocks_monotonic_clock_0_2_0"><code>wasi:clocks/monotonic-clock@0.2.0</code></a></li>
 <li>interface <a href="#wasi_http_types_0_2_0"><code>wasi:http/types@0.2.0</code></a></li>
 <li>interface <a href="#wasi_http_outgoing_handler_0_2_0"><code>wasi:http/outgoing-handler@0.2.0</code></a></li>
-<li>interface <a href="#wasi_clocks_wall_clock_0_2_0"><code>wasi:clocks/wall-clock@0.2.0</code></a></li>
 </ul>
 </li>
+</ul>
+<h2><a name="wasi_io_poll_0_2_0"></a>Import interface wasi:io/poll@0.2.0</h2>
+<p>A poll API intended to let users wait for I/O events on multiple handles
+at once.</p>
+<hr />
+<h3>Types</h3>
+<h4><a name="pollable"></a><code>resource pollable</code></h4>
+<h2><a href="#pollable"><code>pollable</code></a> represents a single I/O event which may be ready, or not.</h2>
+<h3>Functions</h3>
+<h4><a name="method_pollable_ready"></a><code>[method]pollable.ready: func</code></h4>
+<p>Return the readiness of a pollable. This function never blocks.</p>
+<p>Returns <code>true</code> when the pollable is ready, and <code>false</code> otherwise.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="method_pollable_ready.self"></a><code>self</code>: borrow&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="method_pollable_ready.0"></a> <code>bool</code></li>
+</ul>
+<h4><a name="method_pollable_block"></a><code>[method]pollable.block: func</code></h4>
+<p><code>block</code> returns immediately if the pollable is ready, and otherwise
+blocks until ready.</p>
+<p>This function is equivalent to calling <code>poll.poll</code> on a list
+containing only this pollable.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="method_pollable_block.self"></a><code>self</code>: borrow&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
+</ul>
+<h4><a name="poll"></a><code>poll: func</code></h4>
+<p>Poll for completion on a set of pollables.</p>
+<p>This function takes a list of pollables, which identify I/O sources of
+interest, and waits until one or more of the events is ready for I/O.</p>
+<p>The result <code>list&lt;u32&gt;</code> contains one or more indices of handles in the
+argument list that is ready for I/O.</p>
+<p>This function traps if either:</p>
+<ul>
+<li>the list is empty, or:</li>
+<li>the list contains more elements than can be indexed with a <code>u32</code> value.</li>
+</ul>
+<p>A timeout can be implemented by adding a pollable from the
+wasi-clocks API to the list.</p>
+<p>This function does not return a <code>result</code>; polling in itself does not
+do any I/O so it doesn't fail. If any of the I/O sources identified by
+the pollables has an error, it is indicated by marking the source as
+being ready for I/O.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="poll.in"></a><code>in</code>: list&lt;borrow&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;&gt;</li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="poll.0"></a> list&lt;<code>u32</code>&gt;</li>
+</ul>
+<h2><a name="wasi_clocks_monotonic_clock_0_2_0"></a>Import interface wasi:clocks/monotonic-clock@0.2.0</h2>
+<p>WASI Monotonic Clock is a clock API intended to let users measure elapsed
+time.</p>
+<p>It is intended to be portable at least between Unix-family platforms and
+Windows.</p>
+<p>A monotonic clock is a clock which has an unspecified initial value, and
+successive reads of the clock will produce non-decreasing values.</p>
+<hr />
+<h3>Types</h3>
+<h4><a name="pollable"></a><code>type pollable</code></h4>
+<p><a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></p>
+<p>
+#### <a name="instant"></a>`type instant`
+`u64`
+<p>An instant in time, in nanoseconds. An instant is relative to an
+unspecified initial value, and can only be compared to instances from
+the same monotonic-clock.
+<h4><a name="duration"></a><code>type duration</code></h4>
+<p><code>u64</code></p>
+<p>A duration of time, in nanoseconds.
+<hr />
+<h3>Functions</h3>
+<h4><a name="now"></a><code>now: func</code></h4>
+<p>Read the current value of the clock.</p>
+<p>The clock is monotonic, therefore calling this function repeatedly will
+produce a sequence of non-decreasing values.</p>
+<h5>Return values</h5>
+<ul>
+<li><a name="now.0"></a> <a href="#instant"><a href="#instant"><code>instant</code></a></a></li>
+</ul>
+<h4><a name="resolution"></a><code>resolution: func</code></h4>
+<p>Query the resolution of the clock. Returns the duration of time
+corresponding to a clock tick.</p>
+<h5>Return values</h5>
+<ul>
+<li><a name="resolution.0"></a> <a href="#duration"><a href="#duration"><code>duration</code></a></a></li>
+</ul>
+<h4><a name="subscribe_instant"></a><code>subscribe-instant: func</code></h4>
+<p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once the specified instant
+has occurred.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="subscribe_instant.when"></a><code>when</code>: <a href="#instant"><a href="#instant"><code>instant</code></a></a></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="subscribe_instant.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
+</ul>
+<h4><a name="subscribe_duration"></a><code>subscribe-duration: func</code></h4>
+<p>Create a <a href="#pollable"><code>pollable</code></a> that will resolve after the specified duration has
+elapsed from the time this function is invoked.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="subscribe_duration.when"></a><code>when</code>: <a href="#duration"><a href="#duration"><code>duration</code></a></a></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="subscribe_duration.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
+</ul>
+<h2><a name="wasi_clocks_wall_clock_0_2_0"></a>Import interface wasi:clocks/wall-clock@0.2.0</h2>
+<p>WASI Wall Clock is a clock API intended to let users query the current
+time. The name &quot;wall&quot; makes an analogy to a &quot;clock on the wall&quot;, which
+is not necessarily monotonic as it may be reset.</p>
+<p>It is intended to be portable at least between Unix-family platforms and
+Windows.</p>
+<p>A wall clock is a clock which measures the date and time according to
+some external reference.</p>
+<p>External references may be reset, so this clock is not necessarily
+monotonic, making it unsuitable for measuring elapsed time.</p>
+<p>It is intended for reporting the current date and time for humans.</p>
+<hr />
+<h3>Types</h3>
+<h4><a name="datetime"></a><code>record datetime</code></h4>
+<p>A time and date in seconds plus nanoseconds.</p>
+<h5>Record Fields</h5>
+<ul>
+<li><a name="datetime.seconds"></a><code>seconds</code>: <code>u64</code></li>
+<li><a name="datetime.nanoseconds"></a><code>nanoseconds</code>: <code>u32</code></li>
+</ul>
+<hr />
+<h3>Functions</h3>
+<h4><a name="now"></a><code>now: func</code></h4>
+<p>Read the current value of the clock.</p>
+<p>This clock is not monotonic, therefore calling this function repeatedly
+will not necessarily produce a sequence of non-decreasing values.</p>
+<p>The returned timestamps represent the number of seconds since
+1970-01-01T00:00:00Z, also known as <a href="https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16">POSIX's Seconds Since the Epoch</a>,
+also known as <a href="https://en.wikipedia.org/wiki/Unix_time">Unix Time</a>.</p>
+<p>The nanoseconds field of the output is always less than 1000000000.</p>
+<h5>Return values</h5>
+<ul>
+<li><a name="now.0"></a> <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
+</ul>
+<h4><a name="resolution"></a><code>resolution: func</code></h4>
+<p>Query the resolution of the clock.</p>
+<p>The nanoseconds field of the output is always less than 1000000000.</p>
+<h5>Return values</h5>
+<ul>
+<li><a name="resolution.0"></a> <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
 </ul>
 <h2><a name="wasi_random_random_0_2_0"></a>Import interface wasi:random/random@0.2.0</h2>
 <p>WASI Random is a random data API.</p>
@@ -83,59 +236,6 @@ hazard.</p>
 <h5>Return values</h5>
 <ul>
 <li><a name="method_error_to_debug_string.0"></a> <code>string</code></li>
-</ul>
-<h2><a name="wasi_io_poll_0_2_0"></a>Import interface wasi:io/poll@0.2.0</h2>
-<p>A poll API intended to let users wait for I/O events on multiple handles
-at once.</p>
-<hr />
-<h3>Types</h3>
-<h4><a name="pollable"></a><code>resource pollable</code></h4>
-<h2><a href="#pollable"><code>pollable</code></a> represents a single I/O event which may be ready, or not.</h2>
-<h3>Functions</h3>
-<h4><a name="method_pollable_ready"></a><code>[method]pollable.ready: func</code></h4>
-<p>Return the readiness of a pollable. This function never blocks.</p>
-<p>Returns <code>true</code> when the pollable is ready, and <code>false</code> otherwise.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="method_pollable_ready.self"></a><code>self</code>: borrow&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="method_pollable_ready.0"></a> <code>bool</code></li>
-</ul>
-<h4><a name="method_pollable_block"></a><code>[method]pollable.block: func</code></h4>
-<p><code>block</code> returns immediately if the pollable is ready, and otherwise
-blocks until ready.</p>
-<p>This function is equivalent to calling <code>poll.poll</code> on a list
-containing only this pollable.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="method_pollable_block.self"></a><code>self</code>: borrow&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
-</ul>
-<h4><a name="poll"></a><code>poll: func</code></h4>
-<p>Poll for completion on a set of pollables.</p>
-<p>This function takes a list of pollables, which identify I/O sources of
-interest, and waits until one or more of the events is ready for I/O.</p>
-<p>The result <code>list&lt;u32&gt;</code> contains one or more indices of handles in the
-argument list that is ready for I/O.</p>
-<p>This function traps if either:</p>
-<ul>
-<li>the list is empty, or:</li>
-<li>the list contains more elements than can be indexed with a <code>u32</code> value.</li>
-</ul>
-<p>A timeout can be implemented by adding a pollable from the
-wasi-clocks API to the list.</p>
-<p>This function does not return a <code>result</code>; polling in itself does not
-do any I/O so it doesn't fail. If any of the I/O sources identified by
-the pollables has an error, it is indicated by marking the source as
-being ready for I/O.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="poll.in"></a><code>in</code>: list&lt;borrow&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;&gt;</li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="poll.0"></a> list&lt;<code>u32</code>&gt;</li>
 </ul>
 <h2><a name="wasi_io_streams_0_2_0"></a>Import interface wasi:io/streams@0.2.0</h2>
 <p>WASI I/O is an I/O abstraction API which is currently focused on providing
@@ -503,65 +603,6 @@ is ready for reading, before performing the <code>splice</code>.</p>
 <h5>Return values</h5>
 <ul>
 <li><a name="get_stdin.0"></a> own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
-</ul>
-<h2><a name="wasi_clocks_monotonic_clock_0_2_0"></a>Import interface wasi:clocks/monotonic-clock@0.2.0</h2>
-<p>WASI Monotonic Clock is a clock API intended to let users measure elapsed
-time.</p>
-<p>It is intended to be portable at least between Unix-family platforms and
-Windows.</p>
-<p>A monotonic clock is a clock which has an unspecified initial value, and
-successive reads of the clock will produce non-decreasing values.</p>
-<hr />
-<h3>Types</h3>
-<h4><a name="pollable"></a><code>type pollable</code></h4>
-<p><a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></p>
-<p>
-#### <a name="instant"></a>`type instant`
-`u64`
-<p>An instant in time, in nanoseconds. An instant is relative to an
-unspecified initial value, and can only be compared to instances from
-the same monotonic-clock.
-<h4><a name="duration"></a><code>type duration</code></h4>
-<p><code>u64</code></p>
-<p>A duration of time, in nanoseconds.
-<hr />
-<h3>Functions</h3>
-<h4><a name="now"></a><code>now: func</code></h4>
-<p>Read the current value of the clock.</p>
-<p>The clock is monotonic, therefore calling this function repeatedly will
-produce a sequence of non-decreasing values.</p>
-<h5>Return values</h5>
-<ul>
-<li><a name="now.0"></a> <a href="#instant"><a href="#instant"><code>instant</code></a></a></li>
-</ul>
-<h4><a name="resolution"></a><code>resolution: func</code></h4>
-<p>Query the resolution of the clock. Returns the duration of time
-corresponding to a clock tick.</p>
-<h5>Return values</h5>
-<ul>
-<li><a name="resolution.0"></a> <a href="#duration"><a href="#duration"><code>duration</code></a></a></li>
-</ul>
-<h4><a name="subscribe_instant"></a><code>subscribe-instant: func</code></h4>
-<p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once the specified instant
-has occurred.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="subscribe_instant.when"></a><code>when</code>: <a href="#instant"><a href="#instant"><code>instant</code></a></a></li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="subscribe_instant.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
-</ul>
-<h4><a name="subscribe_duration"></a><code>subscribe-duration: func</code></h4>
-<p>Create a <a href="#pollable"><code>pollable</code></a> that will resolve after the specified duration has
-elapsed from the time this function is invoked.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="subscribe_duration.when"></a><code>when</code>: <a href="#duration"><a href="#duration"><code>duration</code></a></a></li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="subscribe_duration.0"></a> own&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi_http_types_0_2_0"></a>Import interface wasi:http/types@0.2.0</h2>
 <p>This interface defines all of the types and methods for implementing
@@ -1489,45 +1530,4 @@ through the <a href="#future_incoming_response"><code>future-incoming-response</
 <h5>Return values</h5>
 <ul>
 <li><a name="handle.0"></a> result&lt;own&lt;<a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
-</ul>
-<h2><a name="wasi_clocks_wall_clock_0_2_0"></a>Import interface wasi:clocks/wall-clock@0.2.0</h2>
-<p>WASI Wall Clock is a clock API intended to let users query the current
-time. The name &quot;wall&quot; makes an analogy to a &quot;clock on the wall&quot;, which
-is not necessarily monotonic as it may be reset.</p>
-<p>It is intended to be portable at least between Unix-family platforms and
-Windows.</p>
-<p>A wall clock is a clock which measures the date and time according to
-some external reference.</p>
-<p>External references may be reset, so this clock is not necessarily
-monotonic, making it unsuitable for measuring elapsed time.</p>
-<p>It is intended for reporting the current date and time for humans.</p>
-<hr />
-<h3>Types</h3>
-<h4><a name="datetime"></a><code>record datetime</code></h4>
-<p>A time and date in seconds plus nanoseconds.</p>
-<h5>Record Fields</h5>
-<ul>
-<li><a name="datetime.seconds"></a><code>seconds</code>: <code>u64</code></li>
-<li><a name="datetime.nanoseconds"></a><code>nanoseconds</code>: <code>u32</code></li>
-</ul>
-<hr />
-<h3>Functions</h3>
-<h4><a name="now"></a><code>now: func</code></h4>
-<p>Read the current value of the clock.</p>
-<p>This clock is not monotonic, therefore calling this function repeatedly
-will not necessarily produce a sequence of non-decreasing values.</p>
-<p>The returned timestamps represent the number of seconds since
-1970-01-01T00:00:00Z, also known as <a href="https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16">POSIX's Seconds Since the Epoch</a>,
-also known as <a href="https://en.wikipedia.org/wiki/Unix_time">Unix Time</a>.</p>
-<p>The nanoseconds field of the output is always less than 1000000000.</p>
-<h5>Return values</h5>
-<ul>
-<li><a name="now.0"></a> <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
-</ul>
-<h4><a name="resolution"></a><code>resolution: func</code></h4>
-<p>Query the resolution of the clock.</p>
-<p>The nanoseconds field of the output is always less than 1000000000.</p>
-<h5>Return values</h5>
-<ul>
-<li><a name="resolution.0"></a> <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
 </ul>

--- a/proxy.md
+++ b/proxy.md
@@ -11,12 +11,12 @@ outgoing HTTP requests.</p>
 <li>interface <a href="#wasi_io_error_0_2_0"><code>wasi:io/error@0.2.0</code></a></li>
 <li>interface <a href="#wasi_io_streams_0_2_0"><code>wasi:io/streams@0.2.0</code></a></li>
 <li>interface <a href="#wasi_http_types_0_2_0"><code>wasi:http/types@0.2.0</code></a></li>
+<li>interface <a href="#wasi_clocks_wall_clock_0_2_0"><code>wasi:clocks/wall-clock@0.2.0</code></a></li>
 <li>interface <a href="#wasi_random_random_0_2_0"><code>wasi:random/random@0.2.0</code></a></li>
 <li>interface <a href="#wasi_cli_stdout_0_2_0"><code>wasi:cli/stdout@0.2.0</code></a></li>
 <li>interface <a href="#wasi_cli_stderr_0_2_0"><code>wasi:cli/stderr@0.2.0</code></a></li>
 <li>interface <a href="#wasi_cli_stdin_0_2_0"><code>wasi:cli/stdin@0.2.0</code></a></li>
 <li>interface <a href="#wasi_http_outgoing_handler_0_2_0"><code>wasi:http/outgoing-handler@0.2.0</code></a></li>
-<li>interface <a href="#wasi_clocks_wall_clock_0_2_0"><code>wasi:clocks/wall-clock@0.2.0</code></a></li>
 </ul>
 </li>
 <li>Exports:
@@ -1388,6 +1388,47 @@ but those will be reported by the <a href="#incoming_body"><code>incoming-body</
 <ul>
 <li><a name="method_future_incoming_response_get.0"></a> option&lt;result&lt;result&lt;own&lt;<a href="#incoming_response"><a href="#incoming_response"><code>incoming-response</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;&gt;&gt;</li>
 </ul>
+<h2><a name="wasi_clocks_wall_clock_0_2_0"></a>Import interface wasi:clocks/wall-clock@0.2.0</h2>
+<p>WASI Wall Clock is a clock API intended to let users query the current
+time. The name &quot;wall&quot; makes an analogy to a &quot;clock on the wall&quot;, which
+is not necessarily monotonic as it may be reset.</p>
+<p>It is intended to be portable at least between Unix-family platforms and
+Windows.</p>
+<p>A wall clock is a clock which measures the date and time according to
+some external reference.</p>
+<p>External references may be reset, so this clock is not necessarily
+monotonic, making it unsuitable for measuring elapsed time.</p>
+<p>It is intended for reporting the current date and time for humans.</p>
+<hr />
+<h3>Types</h3>
+<h4><a name="datetime"></a><code>record datetime</code></h4>
+<p>A time and date in seconds plus nanoseconds.</p>
+<h5>Record Fields</h5>
+<ul>
+<li><a name="datetime.seconds"></a><code>seconds</code>: <code>u64</code></li>
+<li><a name="datetime.nanoseconds"></a><code>nanoseconds</code>: <code>u32</code></li>
+</ul>
+<hr />
+<h3>Functions</h3>
+<h4><a name="now"></a><code>now: func</code></h4>
+<p>Read the current value of the clock.</p>
+<p>This clock is not monotonic, therefore calling this function repeatedly
+will not necessarily produce a sequence of non-decreasing values.</p>
+<p>The returned timestamps represent the number of seconds since
+1970-01-01T00:00:00Z, also known as <a href="https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16">POSIX's Seconds Since the Epoch</a>,
+also known as <a href="https://en.wikipedia.org/wiki/Unix_time">Unix Time</a>.</p>
+<p>The nanoseconds field of the output is always less than 1000000000.</p>
+<h5>Return values</h5>
+<ul>
+<li><a name="now.0"></a> <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
+</ul>
+<h4><a name="resolution"></a><code>resolution: func</code></h4>
+<p>Query the resolution of the clock.</p>
+<p>The nanoseconds field of the output is always less than 1000000000.</p>
+<h5>Return values</h5>
+<ul>
+<li><a name="resolution.0"></a> <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
+</ul>
 <h2><a name="wasi_random_random_0_2_0"></a>Import interface wasi:random/random@0.2.0</h2>
 <p>WASI Random is a random data API.</p>
 <p>It is intended to be portable at least between Unix-family platforms and
@@ -1496,47 +1537,6 @@ through the <a href="#future_incoming_response"><code>future-incoming-response</
 <h5>Return values</h5>
 <ul>
 <li><a name="handle.0"></a> result&lt;own&lt;<a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
-</ul>
-<h2><a name="wasi_clocks_wall_clock_0_2_0"></a>Import interface wasi:clocks/wall-clock@0.2.0</h2>
-<p>WASI Wall Clock is a clock API intended to let users query the current
-time. The name &quot;wall&quot; makes an analogy to a &quot;clock on the wall&quot;, which
-is not necessarily monotonic as it may be reset.</p>
-<p>It is intended to be portable at least between Unix-family platforms and
-Windows.</p>
-<p>A wall clock is a clock which measures the date and time according to
-some external reference.</p>
-<p>External references may be reset, so this clock is not necessarily
-monotonic, making it unsuitable for measuring elapsed time.</p>
-<p>It is intended for reporting the current date and time for humans.</p>
-<hr />
-<h3>Types</h3>
-<h4><a name="datetime"></a><code>record datetime</code></h4>
-<p>A time and date in seconds plus nanoseconds.</p>
-<h5>Record Fields</h5>
-<ul>
-<li><a name="datetime.seconds"></a><code>seconds</code>: <code>u64</code></li>
-<li><a name="datetime.nanoseconds"></a><code>nanoseconds</code>: <code>u32</code></li>
-</ul>
-<hr />
-<h3>Functions</h3>
-<h4><a name="now"></a><code>now: func</code></h4>
-<p>Read the current value of the clock.</p>
-<p>This clock is not monotonic, therefore calling this function repeatedly
-will not necessarily produce a sequence of non-decreasing values.</p>
-<p>The returned timestamps represent the number of seconds since
-1970-01-01T00:00:00Z, also known as <a href="https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16">POSIX's Seconds Since the Epoch</a>,
-also known as <a href="https://en.wikipedia.org/wiki/Unix_time">Unix Time</a>.</p>
-<p>The nanoseconds field of the output is always less than 1000000000.</p>
-<h5>Return values</h5>
-<ul>
-<li><a name="now.0"></a> <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
-</ul>
-<h4><a name="resolution"></a><code>resolution: func</code></h4>
-<p>Query the resolution of the clock.</p>
-<p>The nanoseconds field of the output is always less than 1000000000.</p>
-<h5>Return values</h5>
-<ul>
-<li><a name="resolution.0"></a> <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
 </ul>
 <h2><a name="wasi_http_incoming_handler_0_2_0"></a>Export interface wasi:http/incoming-handler@0.2.0</h2>
 <hr />

--- a/wit/proxy.wit
+++ b/wit/proxy.wit
@@ -6,7 +6,9 @@ package wasi:http@0.2.0;
 world imports {
   /// HTTP proxies have access to time and randomness.
   @since(version = 0.2.0)
-  include wasi:clocks/imports@0.2.0;
+  import wasi:clocks/monotonic-clock@0.2.0;
+  @since(version = 0.2.0)
+  import wasi:clocks/wall-clock@0.2.0;
   @since(version = 0.2.0)
   import wasi:random/random@0.2.0;
 


### PR DESCRIPTION
This changes the `wasi:clocks` `include` statement to individual `import` statements in `wasi:http/proxy`. This came out of a conversation with @sunfishcode yesterday, who pointed out that if we're going to add timezones to `wasi:clocks` (https://github.com/WebAssembly/wasi-clocks/pull/61), `wasi:http/proxy` may not actually want to provide timezone support.

By switching from a catch-all `include` to individual `import` statements, we can decide later whether this is something we'd like to include. But conservatively we can start with the assumption that we won't.

This has some precedent in how we're handling our re-exports of `wasi:cli`: `wasi:http/proxy` includes `wasi:cli/stdin` and `wasi:cli/stdout` - but it does for example not include support for files or sockets.