### PR TITLE
Update request authority documentation

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -994,7 +994,7 @@ list with the same key.</p>
 <li><a name="method_incoming_request_scheme.0"></a> option&lt;<a href="#scheme"><a href="#scheme"><code>scheme</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_incoming_request_authority"></a><code>[method]incoming-request.authority: func</code></h4>
-<p>Returns the authority from the request, if it was present.</p>
+<p>Returns the authority of the Request's target URI, if present.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_request_authority.self"></a><code>self</code>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
@@ -1133,8 +1133,8 @@ string given is not a syntactically valid uri scheme.</p>
 <li><a name="method_outgoing_request_set_scheme.0"></a> result</li>
 </ul>
 <h4><a name="method_outgoing_request_authority"></a><code>[method]outgoing-request.authority: func</code></h4>
-<p>Get the HTTP Authority for the Request. A value of <code>none</code> may be used
-with Related Schemes which do not require an Authority. The HTTP and
+<p>Get the authority of the Request's target URI. A value of <code>none</code> may be used
+with Related Schemes which do not require an authority. The HTTP and
 HTTPS schemes always require an authority.</p>
 <h5>Params</h5>
 <ul>
@@ -1145,10 +1145,10 @@ HTTPS schemes always require an authority.</p>
 <li><a name="method_outgoing_request_authority.0"></a> option&lt;<code>string</code>&gt;</li>
 </ul>
 <h4><a name="method_outgoing_request_set_authority"></a><code>[method]outgoing-request.set-authority: func</code></h4>
-<p>Set the HTTP Authority for the Request. A value of <code>none</code> may be used
-with Related Schemes which do not require an Authority. The HTTP and
+<p>Set the authority of the Request's target URI. A value of <code>none</code> may be used
+with Related Schemes which do not require an authority. The HTTP and
 HTTPS schemes always require an authority. Fails if the string given is
-not a syntactically valid uri authority.</p>
+not a syntactically valid URI authority.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_outgoing_request_set_authority.self"></a><code>self</code>: borrow&lt;<a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a>&gt;</li>

--- a/proxy.md
+++ b/proxy.md
@@ -888,7 +888,7 @@ list with the same key.</p>
 <li><a name="method_incoming_request_scheme.0"></a> option&lt;<a href="#scheme"><a href="#scheme"><code>scheme</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_incoming_request_authority"></a><code>[method]incoming-request.authority: func</code></h4>
-<p>Returns the authority from the request, if it was present.</p>
+<p>Returns the authority of the Request's target URI, if present.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_incoming_request_authority.self"></a><code>self</code>: borrow&lt;<a href="#incoming_request"><a href="#incoming_request"><code>incoming-request</code></a></a>&gt;</li>
@@ -1027,8 +1027,8 @@ string given is not a syntactically valid uri scheme.</p>
 <li><a name="method_outgoing_request_set_scheme.0"></a> result</li>
 </ul>
 <h4><a name="method_outgoing_request_authority"></a><code>[method]outgoing-request.authority: func</code></h4>
-<p>Get the HTTP Authority for the Request. A value of <code>none</code> may be used
-with Related Schemes which do not require an Authority. The HTTP and
+<p>Get the authority of the Request's target URI. A value of <code>none</code> may be used
+with Related Schemes which do not require an authority. The HTTP and
 HTTPS schemes always require an authority.</p>
 <h5>Params</h5>
 <ul>
@@ -1039,10 +1039,10 @@ HTTPS schemes always require an authority.</p>
 <li><a name="method_outgoing_request_authority.0"></a> option&lt;<code>string</code>&gt;</li>
 </ul>
 <h4><a name="method_outgoing_request_set_authority"></a><code>[method]outgoing-request.set-authority: func</code></h4>
-<p>Set the HTTP Authority for the Request. A value of <code>none</code> may be used
-with Related Schemes which do not require an Authority. The HTTP and
+<p>Set the authority of the Request's target URI. A value of <code>none</code> may be used
+with Related Schemes which do not require an authority. The HTTP and
 HTTPS schemes always require an authority. Fails if the string given is
-not a syntactically valid uri authority.</p>
+not a syntactically valid URI authority.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_outgoing_request_set_authority.self"></a><code>self</code>: borrow&lt;<a href="#outgoing_request"><a href="#outgoing_request"><code>outgoing-request</code></a></a>&gt;</li>

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -304,14 +304,14 @@ interface types {
     /// string given is not a syntactically valid uri scheme.
     set-scheme: func(scheme: option<scheme>) -> result;
 
-    /// Get the HTTP Authority for the Request. A value of `none` may be used
-    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// Get the authority of the Request's target URI. A value of `none` may be used
+    /// with Related Schemes which do not require an authority. The HTTP and
     /// HTTPS schemes always require an authority.
     authority: func() -> option<string>;
-    /// Set the HTTP Authority for the Request. A value of `none` may be used
-    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// Set the authority of the Request's target URI. A value of `none` may be used
+    /// with Related Schemes which do not require an authority. The HTTP and
     /// HTTPS schemes always require an authority. Fails if the string given is
-    /// not a syntactically valid uri authority.
+    /// not a syntactically valid URI authority.
     set-authority: func(authority: option<string>) -> result;
 
     /// Get the `request-options` to be associated with this request

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -267,7 +267,7 @@ interface types {
     @since(version = 0.2.0)
     scheme: func() -> option<scheme>;
 
-    /// Returns the authority from the request, if it was present.
+    /// Returns the authority of the Request's target URI, if present.
     @since(version = 0.2.0)
     authority: func() -> option<string>;
 
@@ -344,15 +344,15 @@ interface types {
     @since(version = 0.2.0)
     set-scheme: func(scheme: option<scheme>) -> result;
 
-    /// Get the HTTP Authority for the Request. A value of `none` may be used
-    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// Get the authority of the Request's target URI. A value of `none` may be used
+    /// with Related Schemes which do not require an authority. The HTTP and
     /// HTTPS schemes always require an authority.
     @since(version = 0.2.0)
     authority: func() -> option<string>;
-    /// Set the HTTP Authority for the Request. A value of `none` may be used
-    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// Set the authority of the Request's target URI. A value of `none` may be used
+    /// with Related Schemes which do not require an authority. The HTTP and
     /// HTTPS schemes always require an authority. Fails if the string given is
-    /// not a syntactically valid uri authority.
+    /// not a syntactically valid URI authority.
     @since(version = 0.2.0)
     set-authority: func(authority: option<string>) -> result;
 


### PR DESCRIPTION
The existing wording refers to a "request's authority", which is not clearly defined by HTTP specs.

This rewords it to refer to the "request's target URI authority" - the "authority" part of the "target URI" of the request, which is well-defined: https://httpwg.org/http-core/draft-ietf-httpbis-semantics-latest.html#target.resource

Also normalize some word casing to match the HTTP Semantics doc.