### PR TITLE
http: note field keys returned have whitespace trimmed

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -943,6 +943,8 @@ constructor, the list represents each key-value pair.</p>
 <p>The outer list represents each key-value pair in the Fields. Keys
 which have multiple values are represented by multiple entries in this
 list with the same key.</p>
+<p>Returned field keys do not include leading or trailing whitespace
+characters 0x0a, 0x0d, 0x09 and 0x20.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_fields_entries.self"></a><code>self</code>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>

--- a/proxy.md
+++ b/proxy.md
@@ -837,6 +837,8 @@ constructor, the list represents each key-value pair.</p>
 <p>The outer list represents each key-value pair in the Fields. Keys
 which have multiple values are represented by multiple entries in this
 list with the same key.</p>
+<p>Returned field keys do not include leading or trailing whitespace
+characters 0x0a, 0x0d, 0x09 and 0x20.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="method_fields_entries.self"></a><code>self</code>: borrow&lt;<a href="#fields"><a href="#fields"><code>fields</code></a></a>&gt;</li>

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -233,8 +233,11 @@ interface types {
     /// The outer list represents each key-value pair in the Fields. Keys
     /// which have multiple values are represented by multiple entries in this
     /// list with the same key.
+    ///
+    /// Returned field keys do not include leading or trailing whitespace
+    /// characters 0x0a, 0x0d, 0x09 and 0x20.
     @since(version = 0.2.0)
-    entries: func() -> list<tuple<field-key,field-value>>;
+    entries: func() -> list<tuple<field-key, field-value>>;
 
     /// Make a deep copy of the Fields. Equivalent in behavior to calling the
     /// `fields` constructor on the return value of `entries`. The resulting


### PR DESCRIPTION
Resolves https://github.com/WebAssembly/wasi-http/issues/123, in allowing better optimizations for implementations since this is the only normalization (as opposed to validation) step required for field keys in the fetch specification.