### PR TITLE
feat(proxy): add config to proxy world

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,3 +21,4 @@ jobs:
         wasm-tools: '1.215.0'
         wit-bindgen: '0.30.0'
         worlds: 'imports proxy'
+        features: 'config'

--- a/imports.md
+++ b/imports.md
@@ -13,6 +13,7 @@ It is intended to be <code>include</code>d in other worlds.</p>
 <li>interface <a href="#wasi_cli_stdout_0_2_1"><code>wasi:cli/stdout@0.2.1</code></a></li>
 <li>interface <a href="#wasi_cli_stderr_0_2_1"><code>wasi:cli/stderr@0.2.1</code></a></li>
 <li>interface <a href="#wasi_cli_stdin_0_2_1"><code>wasi:cli/stdin@0.2.1</code></a></li>
+<li>interface <a href="#wasi_config_runtime_0_2_0_draft"><code>wasi:config/runtime@0.2.0-draft</code></a></li>
 <li>interface <a href="#wasi_http_types_0_2_1"><code>wasi:http/types@0.2.1</code></a></li>
 <li>interface <a href="#wasi_http_outgoing_handler_0_2_1"><code>wasi:http/outgoing-handler@0.2.1</code></a></li>
 </ul>
@@ -258,6 +259,8 @@ when it does, they are expected to subsume this API.</p>
 <p><a id="stream_error.last_operation_failed"></a><code>last-operation-failed</code>: own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;</p>
 <p>The last operation (a write or flush) failed before completion.
 <p>More information is available in the <a href="#error"><code>error</code></a> payload.</p>
+<p>After this, the stream will be closed. All future operations return
+<a href="#stream_error.closed"><code>stream-error::closed</code></a>.</p>
 </li>
 <li>
 <p><a id="stream_error.closed"></a><code>closed</code></p>
@@ -604,6 +607,47 @@ is ready for reading, before performing the <code>splice</code>.</p>
 <ul>
 <li><a id="get_stdin.0"></a> own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
 </ul>
+<h2><a id="wasi_config_runtime_0_2_0_draft"></a>Import interface wasi:config/runtime@0.2.0-draft</h2>
+<hr />
+<h3>Types</h3>
+<h4><a id="config_error"></a><code>variant config-error</code></h4>
+<p>An error type that encapsulates the different errors that can occur fetching config</p>
+<h5>Variant Cases</h5>
+<ul>
+<li>
+<p><a id="config_error.upstream"></a><code>upstream</code>: <code>string</code></p>
+<p>This indicates an error from an "upstream" config source.
+As this could be almost _anything_ (such as Vault, Kubernetes ConfigMaps, KeyValue buckets, etc),
+the error message is a string.
+</li>
+<li>
+<p><a id="config_error.io"></a><code>io</code>: <code>string</code></p>
+<p>This indicates an error from an I/O operation.
+As this could be almost _anything_ (such as a file read, network connection, etc),
+the error message is a string.
+Depending on how this ends up being consumed,
+we may consider moving this to use the `wasi:io/error` type instead.
+For simplicity right now in supporting multiple implementations, it is being left as a string.
+</li>
+</ul>
+<hr />
+<h3>Functions</h3>
+<h4><a id="get"></a><code>get: func</code></h4>
+<p>Gets a single opaque config value set at the given key if it exists</p>
+<h5>Params</h5>
+<ul>
+<li><a id="get.key"></a><code>key</code>: <code>string</code></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a id="get.0"></a> result&lt;option&lt;<code>string</code>&gt;, <a href="#config_error"><a href="#config_error"><code>config-error</code></a></a>&gt;</li>
+</ul>
+<h4><a id="get_all"></a><code>get-all: func</code></h4>
+<p>Gets a list of all set config data</p>
+<h5>Return values</h5>
+<ul>
+<li><a id="get_all.0"></a> result&lt;list&lt;(<code>string</code>, <code>string</code>)&gt;, <a href="#config_error"><a href="#config_error"><code>config-error</code></a></a>&gt;</li>
+</ul>
 <h2><a id="wasi_http_types_0_2_1"></a>Import interface wasi:http/types@0.2.1</h2>
 <p>This interface defines all of the types and methods for implementing
 HTTP Requests and Responses, both incoming and outgoing, as well as
@@ -629,7 +673,7 @@ their headers, trailers, and bodies.</p>
 <p>This type corresponds to HTTP standard Methods.</p>
 <h5>Variant Cases</h5>
 <ul>
-<li><a id="method.get"></a><code>get</code></li>
+<li><a id="method.get"></a><a href="#get"><code>get</code></a></li>
 <li><a id="method.head"></a><code>head</code></li>
 <li><a id="method.post"></a><code>post</code></li>
 <li><a id="method.put"></a><code>put</code></li>
@@ -1341,7 +1385,7 @@ This function will trap if the <a href="#input_stream"><code>input-stream</code>
 <h4><a id="method_future_trailers_subscribe"></a><code>[method]future-trailers.subscribe: func</code></h4>
 <p>Returns a pollable which becomes ready when either the trailers have
 been received, or an error has occurred. When this pollable is ready,
-the <code>get</code> method will return <code>some</code>.</p>
+the <a href="#get"><code>get</code></a> method will return <code>some</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a id="method_future_trailers_subscribe.self"></a><code>self</code>: borrow&lt;<a href="#future_trailers"><a href="#future_trailers"><code>future-trailers</code></a></a>&gt;</li>
@@ -1476,7 +1520,7 @@ Content-Length.</p>
 <h4><a id="method_future_incoming_response_subscribe"></a><code>[method]future-incoming-response.subscribe: func</code></h4>
 <p>Returns a pollable which becomes ready when either the Response has
 been received, or an error has occurred. When this pollable is ready,
-the <code>get</code> method will return <code>some</code>.</p>
+the <a href="#get"><code>get</code></a> method will return <code>some</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a id="method_future_incoming_response_subscribe.self"></a><code>self</code>: borrow&lt;<a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a>&gt;</li>

--- a/proxy.md
+++ b/proxy.md
@@ -16,6 +16,7 @@ outgoing HTTP requests.</p>
 <li>interface <a href="#wasi_cli_stdout_0_2_1"><code>wasi:cli/stdout@0.2.1</code></a></li>
 <li>interface <a href="#wasi_cli_stderr_0_2_1"><code>wasi:cli/stderr@0.2.1</code></a></li>
 <li>interface <a href="#wasi_cli_stdin_0_2_1"><code>wasi:cli/stdin@0.2.1</code></a></li>
+<li>interface <a href="#wasi_config_runtime_0_2_0_draft"><code>wasi:config/runtime@0.2.0-draft</code></a></li>
 <li>interface <a href="#wasi_http_outgoing_handler_0_2_1"><code>wasi:http/outgoing-handler@0.2.1</code></a></li>
 </ul>
 </li>
@@ -191,6 +192,8 @@ when it does, they are expected to subsume this API.</p>
 <p><a id="stream_error.last_operation_failed"></a><code>last-operation-failed</code>: own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;</p>
 <p>The last operation (a write or flush) failed before completion.
 <p>More information is available in the <a href="#error"><code>error</code></a> payload.</p>
+<p>After this, the stream will be closed. All future operations return
+<a href="#stream_error.closed"><code>stream-error::closed</code></a>.</p>
 </li>
 <li>
 <p><a id="stream_error.closed"></a><code>closed</code></p>
@@ -523,7 +526,7 @@ their headers, trailers, and bodies.</p>
 <p>This type corresponds to HTTP standard Methods.</p>
 <h5>Variant Cases</h5>
 <ul>
-<li><a id="method.get"></a><code>get</code></li>
+<li><a id="method.get"></a><a href="#get"><code>get</code></a></li>
 <li><a id="method.head"></a><code>head</code></li>
 <li><a id="method.post"></a><code>post</code></li>
 <li><a id="method.put"></a><code>put</code></li>
@@ -1235,7 +1238,7 @@ This function will trap if the <a href="#input_stream"><code>input-stream</code>
 <h4><a id="method_future_trailers_subscribe"></a><code>[method]future-trailers.subscribe: func</code></h4>
 <p>Returns a pollable which becomes ready when either the trailers have
 been received, or an error has occurred. When this pollable is ready,
-the <code>get</code> method will return <code>some</code>.</p>
+the <a href="#get"><code>get</code></a> method will return <code>some</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a id="method_future_trailers_subscribe.self"></a><code>self</code>: borrow&lt;<a href="#future_trailers"><a href="#future_trailers"><code>future-trailers</code></a></a>&gt;</li>
@@ -1370,7 +1373,7 @@ Content-Length.</p>
 <h4><a id="method_future_incoming_response_subscribe"></a><code>[method]future-incoming-response.subscribe: func</code></h4>
 <p>Returns a pollable which becomes ready when either the Response has
 been received, or an error has occurred. When this pollable is ready,
-the <code>get</code> method will return <code>some</code>.</p>
+the <a href="#get"><code>get</code></a> method will return <code>some</code>.</p>
 <h5>Params</h5>
 <ul>
 <li><a id="method_future_incoming_response_subscribe.self"></a><code>self</code>: borrow&lt;<a href="#future_incoming_response"><a href="#future_incoming_response"><code>future-incoming-response</code></a></a>&gt;</li>
@@ -1511,6 +1514,47 @@ represented as a <code>u64</code>.</p>
 <h5>Return values</h5>
 <ul>
 <li><a id="get_stdin.0"></a> own&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>&gt;</li>
+</ul>
+<h2><a id="wasi_config_runtime_0_2_0_draft"></a>Import interface wasi:config/runtime@0.2.0-draft</h2>
+<hr />
+<h3>Types</h3>
+<h4><a id="config_error"></a><code>variant config-error</code></h4>
+<p>An error type that encapsulates the different errors that can occur fetching config</p>
+<h5>Variant Cases</h5>
+<ul>
+<li>
+<p><a id="config_error.upstream"></a><code>upstream</code>: <code>string</code></p>
+<p>This indicates an error from an "upstream" config source.
+As this could be almost _anything_ (such as Vault, Kubernetes ConfigMaps, KeyValue buckets, etc),
+the error message is a string.
+</li>
+<li>
+<p><a id="config_error.io"></a><code>io</code>: <code>string</code></p>
+<p>This indicates an error from an I/O operation.
+As this could be almost _anything_ (such as a file read, network connection, etc),
+the error message is a string.
+Depending on how this ends up being consumed,
+we may consider moving this to use the `wasi:io/error` type instead.
+For simplicity right now in supporting multiple implementations, it is being left as a string.
+</li>
+</ul>
+<hr />
+<h3>Functions</h3>
+<h4><a id="get"></a><code>get: func</code></h4>
+<p>Gets a single opaque config value set at the given key if it exists</p>
+<h5>Params</h5>
+<ul>
+<li><a id="get.key"></a><code>key</code>: <code>string</code></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a id="get.0"></a> result&lt;option&lt;<code>string</code>&gt;, <a href="#config_error"><a href="#config_error"><code>config-error</code></a></a>&gt;</li>
+</ul>
+<h4><a id="get_all"></a><code>get-all: func</code></h4>
+<p>Gets a list of all set config data</p>
+<h5>Return values</h5>
+<ul>
+<li><a id="get_all.0"></a> result&lt;list&lt;(<code>string</code>, <code>string</code>)&gt;, <a href="#config_error"><a href="#config_error"><code>config-error</code></a></a>&gt;</li>
 </ul>
 <h2><a id="wasi_http_outgoing_handler_0_2_1"></a>Import interface wasi:http/outgoing-handler@0.2.1</h2>
 <p>This interface defines a handler of outgoing HTTP Requests. It should be

--- a/wit/deps.lock
+++ b/wit/deps.lock
@@ -8,15 +8,20 @@ url = "https://github.com/WebAssembly/wasi-clocks/archive/main.tar.gz"
 sha256 = "ea9d69ee803bc176e23e5268f5e24a2ac485dd1f62a0ab4c748e9d3f901f576f"
 sha512 = "5efc22927c46cd56c41e5549ec775561c7fac2ea0d365abc0b55396d9475a7c9f984077a81f84a44a726f1c008fd2fadbffffa4fa53ecd5fbfd05afd379ab428"
 
+[config]
+url = "https://github.com/WebAssembly/wasi-runtime-config/archive/main.tar.gz"
+sha256 = "9148c06861712b69170af7b8ec37896b4104297d920fdec9f3bcc0b1eee4a5c8"
+sha512 = "25a54101620f279c835b39f56f6dbf8a92b374b6faaf6cf6aaa1ea06d8b97b9b79788cf8abd9c2ad0c11e3629dba6a2513b71f2c54b9f95027054ae54a4615b8"
+
 [filesystem]
 url = "https://github.com/WebAssembly/wasi-filesystem/archive/main.tar.gz"
-sha256 = "cfe8c420e8b857de612ae2a3336680dae16b95c93c8ba3a6ff05b21210966740"
-sha512 = "3c00c5544a58658e3e8025677091685286027fd49f37abf198c30b4e83b9e68f19723975aaa98794fba9f425ae9ef4f3dc0f5b9cf59203b5ecfaadf62b296f9a"
+sha256 = "c8f6224d2c7ac8dd0d0b94f637439226f8010a929abfe6bc7fee52cc325f378b"
+sha512 = "90aa55351ca9d7a582e115f3f2cea87f0bd3937d5b115ff00f21ca2c0056d0f3f91fe5c500ca3515bc477b58e10bb5c9c783d7cda8efad23c2466d2a475d8303"
 
 [io]
 url = "https://github.com/WebAssembly/wasi-io/archive/main.tar.gz"
-sha256 = "2a74bd811adc46b5a0f19827ddbde89870e52b17615f4d0873f06fd977250caf"
-sha512 = "94624f00c66e66203592cee820f80b1ba91ecdb71f682c154f25eaf71f8d8954197dcb64503bc21e72ed5e812af7eae876df47b7eb727b02db3a74a7ce0aefca"
+sha256 = "47d2cfaacb3648de9b0b3458e87363d21e28440506036e8f32896129b7512f9b"
+sha512 = "594ce1a78fda400de47a45044308472e7ea5f37a8e6a5d2fa28b067a8e2d0954dd84d4b1d764b1c343935bb2b24e89364e82deaa17e97bbb5cbf1667bad1202c"
 
 [random]
 url = "https://github.com/WebAssembly/wasi-random/archive/main.tar.gz"

--- a/wit/deps.toml
+++ b/wit/deps.toml
@@ -5,3 +5,4 @@ clocks = "https://github.com/WebAssembly/wasi-clocks/archive/main.tar.gz"
 # not used by http/proxy, but included to allow full contents of wasi-cli to validate
 filesystem = "https://github.com/WebAssembly/wasi-filesystem/archive/main.tar.gz"
 sockets = "https://github.com/WebAssembly/wasi-sockets/archive/main.tar.gz"
+config = "https://github.com/WebAssembly/wasi-runtime-config/archive/main.tar.gz"

--- a/wit/deps/config/runtime_config.wit
+++ b/wit/deps/config/runtime_config.wit
@@ -1,0 +1,25 @@
+interface runtime {
+    /// An error type that encapsulates the different errors that can occur fetching config
+    variant config-error {
+        /// This indicates an error from an "upstream" config source. 
+        /// As this could be almost _anything_ (such as Vault, Kubernetes ConfigMaps, KeyValue buckets, etc), 
+        /// the error message is a string.
+        upstream(string),
+        /// This indicates an error from an I/O operation. 
+        /// As this could be almost _anything_ (such as a file read, network connection, etc), 
+        /// the error message is a string. 
+        /// Depending on how this ends up being consumed, 
+        /// we may consider moving this to use the `wasi:io/error` type instead. 
+        /// For simplicity right now in supporting multiple implementations, it is being left as a string.
+        io(string),
+    }
+
+    /// Gets a single opaque config value set at the given key if it exists
+    get: func(
+        /// A string key to fetch
+        key: string
+    ) -> result<option<string>, config-error>;
+
+    /// Gets a list of all set config data
+    get-all: func() -> result<list<tuple<string, string>>, config-error>;
+}

--- a/wit/deps/config/world.wit
+++ b/wit/deps/config/world.wit
@@ -1,0 +1,6 @@
+package wasi:config@0.2.0-draft;
+
+world imports {
+    /// The runtime interface for config
+    import runtime;
+}

--- a/wit/deps/filesystem/types.wit
+++ b/wit/deps/filesystem/types.wit
@@ -523,12 +523,6 @@ interface types {
 
         /// Open a file or directory.
         ///
-        /// The returned descriptor is not guaranteed to be the lowest-numbered
-        /// descriptor not currently open/ it is randomized to prevent applications
-        /// from depending on making assumptions about indexes, since this is
-        /// error-prone in multi-threaded contexts. The returned descriptor is
-        /// guaranteed to be less than 2**31.
-        ///
         /// If `flags` contains `descriptor-flags::mutate-directory`, and the base
         /// descriptor doesn't have `descriptor-flags::mutate-directory` set,
         /// `open-at` fails with `error-code::read-only`.

--- a/wit/deps/io/streams.wit
+++ b/wit/deps/io/streams.wit
@@ -18,6 +18,9 @@ interface streams {
         /// The last operation (a write or flush) failed before completion.
         ///
         /// More information is available in the `error` payload.
+        ///
+        /// After this, the stream will be closed. All future operations return
+        /// `stream-error::closed`.
         last-operation-failed(error),
         /// The stream is closed: no more input will be accepted by the
         /// stream. A closed output-stream will return this error on all
@@ -205,6 +208,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `output-stream`.
         /// Implementations may trap if the `output-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
 
         /// Write zeroes to a stream.

--- a/wit/proxy.wit
+++ b/wit/proxy.wit
@@ -26,6 +26,11 @@ world imports {
   @since(version = 0.2.0)
   import wasi:cli/stdin@0.2.1;
 
+  /// HTTP proxies to read runtime configurations such as environment variables,
+  /// API keys, and other configuration data.
+  @unstable(feature = config)
+  import wasi:config/runtime@0.2.0-draft;
+
   /// This is the default handler to use when user code simply wants to make an
   /// HTTP request (e.g., via `fetch()`).
   @since(version = 0.2.0)


### PR DESCRIPTION
As stated in #116, http proxy has common use cases for reading configurations from an external provider or local environment variables. This PR adds `wasi:config/runtime@0.2.0-draft` as an import to the Proxy world. Since `wasi:config` is still in phase 2 and this new feature is not discussed / approved in WASI meetings, it's behind the `unstable` gate. 

CC @lukewagner for advocating it, and @yoshuawuyts for a review. 