### PR TITLE
Enclose URLs in documentation with angle brakcets.

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -673,7 +673,7 @@ their headers, trailers, and bodies.</p>
 </ul>
 <h4><a id="error_code"></a><code>variant error-code</code></h4>
 <p>These cases are inspired by the IANA HTTP Proxy Error Types:
-https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types</p>
+<a href="https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types">https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types</a></p>
 <h5>Variant Cases</h5>
 <ul>
 <li><a id="error_code.dns_timeout"></a><code>DNS-timeout</code></li>

--- a/proxy.md
+++ b/proxy.md
@@ -680,7 +680,7 @@ their headers, trailers, and bodies.</p>
 </ul>
 <h4><a id="error_code"></a><code>variant error-code</code></h4>
 <p>These cases are inspired by the IANA HTTP Proxy Error Types:
-https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types</p>
+<a href="https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types">https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types</a></p>
 <h5>Variant Cases</h5>
 <ul>
 <li><a id="error_code.dns_timeout"></a><code>DNS-timeout</code></li>

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -26,7 +26,7 @@ interface types {
   }
 
   /// These cases are inspired by the IANA HTTP Proxy Error Types:
-  ///   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
+  ///   <https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types>
   variant error-code {
     DNS-timeout,
     DNS-error(DNS-error-payload),

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -36,7 +36,7 @@ interface types {
   }
 
   /// These cases are inspired by the IANA HTTP Proxy Error Types:
-  ///   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
+  ///   <https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types>
   @since(version = 0.2.0)
   variant error-code {
     DNS-timeout,


### PR DESCRIPTION
Put angle brackets around URLs in documentation, to help documentation tools like cargo doc generate clickable links for them.