### PR TITLE
add `response-outparam.send-informational`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,5 +19,5 @@ jobs:
     - uses: WebAssembly/wit-abi-up-to-date@v22
       with:
         wasm-tools: '1.218.0'
-        wit-bindgen: '0.33.0'
+        wit-bindgen: '0.37.0'
         worlds: 'imports proxy'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,6 @@ jobs:
         ./wit-deps lock --check
     - uses: WebAssembly/wit-abi-up-to-date@v22
       with:
-        wasm-tools: '1.218.0'
+        wasm-tools: '1.223.0'
         wit-bindgen: '0.37.0'
         worlds: 'imports proxy'

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -435,6 +435,21 @@ interface types {
   /// other argument to `incoming-handler.handle`.
   @since(version = 0.2.0)
   resource response-outparam {
+    /// Send an HTTP 1xx response.
+    ///
+    /// Unlike `response-outparam.set`, this does not consume the
+    /// `response-outparam`, allowing the guest to send an arbitrary number of
+    /// informational responses before sending the final response using
+    /// `response-outparam.set`.
+    ///
+    /// This will return an `HTTP-protocol-error` if `status` is not in the
+    /// range [100-199], or an `internal-error` if the implementation does not
+    /// support informational responses.
+    @unstable(feature = informational-outbound-responses)
+    send-informational: func(
+      status: u16,
+      headers: headers
+    ) -> result<_, error-code>;
 
     /// Set the value of the `response-outparam` to either send a response,
     /// or indicate an error.


### PR DESCRIPTION
This allows a server to send zero or more HTTP 1xx responses prior to sending the final response using `response-outparam.set`.

Note that this does not include support for consuming informational responses for outbound requests (which would be required to losslessly proxy such requests).