### PR TITLE
feat(0.3): rework stream error handling/remove `wasi:io` usage

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -2,7 +2,6 @@
 /// Requests and Responses, as well as their headers, trailers, and bodies.
 interface types {
   use wasi:clocks/monotonic-clock@0.3.0.{duration};
-  use wasi:io/error@0.2.3.{error};
 
   /// This type corresponds to HTTP standard Methods.
   variant method {
@@ -91,18 +90,6 @@ interface types {
     field-name: option<string>,
     field-size: option<u32>
   }
-
-  /// Attempts to extract a http-related `error-code` from the stream `error`
-  /// provided.
-  ///
-  /// Stream operations may fail with a stream `error` with more information
-  /// about the operation that failed. This `error` can be passed to this
-  /// function to see if there's http-related information about the error to
-  /// return.
-  ///
-  /// Note that this function is fallible because not all stream errors are
-  /// http-related errors.
-  http-error-code: func(err: borrow<error>) -> option<error-code>;
 
   /// This type enumerates the different kinds of errors that may occur when
   /// setting or appending to a `fields` resource.
@@ -254,16 +241,24 @@ interface types {
   resource body {
 
     /// Construct a new `body` with the specified stream and trailers.
-    constructor(
+    /// This function returns a future, which will resolve
+    /// to an error code if transmitting stream data or trailers fails.
+    /// The returned future resolves to success once body stream and trailers
+    /// are fully transmitted.
+    new: static func(
       %stream: stream<u8>,
       trailers: option<future<trailers>>
-    );
+    ) -> tuple<body, future<result<_, error-code>>>;
 
     /// Returns the contents of the body, as a stream of bytes.
     ///
     /// This function may be called multiple times as long as any `stream`s
     /// returned by previous calls have been dropped first.
-    %stream: func() -> result<stream<u8>>;
+    ///
+    /// On success, this function returns a stream and a future, which will resolve
+    /// to an error code if receiving data from stream fails.
+    /// The returned future resolves to success if body is closed.
+    %stream: func() -> result<tuple<stream<u8>>, future<result<_, error-code>>>;
 
     /// Takes ownership of `body`, and returns a `trailers`.  This function will
     /// trap if a `stream` child is still alive.


### PR DESCRIPTION
Remove `wasi:io` usage in `wit-0.3.0-draft`

Followed the same stream error handling convention as currently in
- https://github.com/WebAssembly/wasi-filesystem/pull/164
- https://github.com/WebAssembly/wasi-sockets/pull/111