### PR TITLE
feat(p3): only allow `body.stream` calls once

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -265,8 +265,7 @@ interface types {
 
     /// Returns the contents of the body, as a stream of bytes.
     ///
-    /// This function may be called multiple times as long as any `stream`s
-    /// returned by previous calls have been dropped first.
+    /// This can be called at most once per body.
     ///
     /// On success, this function returns a stream and a future, which will resolve
     /// to an error code if receiving data from stream fails.


### PR DESCRIPTION
Only allow `body.stream` to be called once.

This simplifies the host implementation and the amount of bookkeeping that would need to be performed by the runtime. I cannot really come up with a use case that would be impossible for guests to implement using the "at-most-once" call semantics.

We can always relax this requirement at a later point of time if it becomes an issue, but we can't quite go the other way round

This is aligned with e.g.:
- `tcp-socket.receive` https://github.com/WebAssembly/wasi-sockets/blob/41d707935af71418ea5477d5fc9c7281353fa7f5/wit-0.3.0-draft/types.wit#L326-L346
- `tcp-socket.listen` https://github.com/WebAssembly/wasi-sockets/blob/41d707935af71418ea5477d5fc9c7281353fa7f5/wit-0.3.0-draft/types.wit#L226-L289