### PR TITLE
feat(p3): allow trailer retrieval to fail

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -273,10 +273,10 @@ interface types {
     /// The returned future resolves to success if body is closed.
     %stream: func() -> result<tuple<stream<u8>, future<result<_, error-code>>>>;
 
-    /// Takes ownership of `body`, and returns an unresolved optional `trailers`.
+    /// Takes ownership of `body`, and returns an unresolved optional `trailers` result.
     ///
     /// This function will trap if a `stream` child is still alive.
-    finish: static func(this: body) -> future<option<trailers>>;
+    finish: static func(this: body) -> future<result<option<trailers>, error-code>>;
   }
 
   /// Represents an HTTP Request.


### PR DESCRIPTION
Refs #154 
Retrieving trailers implies reading the body of the response, which is a fallible operation.
Currently, guests that call `finish` without calling `stream` first have no way to acquire the `error-code` that the operation might have failed with (due to the implicit read of the body). Even in cases where the data frames of the body might have been fully read before calling `finish`, reading of the trailers can potentially still fail.