### PR TITLE
fix(p3): allow taking response/request body at most once

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -356,6 +356,8 @@ interface types {
 
     /// Get the body associated with the Request, if any.
     ///
+    /// After being called once, consequent calls with return `none`.
+    ///
     /// This body resource is a child: it must be dropped before the parent
     /// `request` is dropped, or its ownership is transferred to another
     /// component by e.g. `handler.handle`.
@@ -438,6 +440,8 @@ interface types {
     headers: func() -> headers;
 
     /// Get the body associated with the Response, if any.
+    ///
+    /// After being called once, consequent calls with return `none`.
     ///
     /// This body resource is a child: it must be dropped before the parent
     /// `response` is dropped, or its ownership is transferred to another


### PR DESCRIPTION
Similar to #156, specify that the request/response body can be taken only once.

If callers were able to get N references to the body, then they would be able to call `body.finish` N times, which would require multiplexing in the host to provide N copies of e.g. the trailers to these N references. It's hard to imagine a use case for this pattern and it also not a common pattern in HTTP libraries as far as I know, so specify that body can only be taken once.