### PR TITLE
fix(p3): remove `body` accessors

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -354,13 +354,6 @@ interface types {
     /// component by e.g. `handler.handle`.
     headers: func() -> headers;
 
-    /// Get the body associated with the Request, if any.
-    ///
-    /// This body resource is a child: it must be dropped before the parent
-    /// `request` is dropped, or its ownership is transferred to another
-    /// component by e.g. `handler.handle`.
-    body: func() -> option<body>;
-
     /// Takes ownership of the `request` and returns the `headers` and `body`,
     /// if any.
     into-parts: static func(this: request) -> tuple<headers, option<body>>;
@@ -436,13 +429,6 @@ interface types {
     /// `response` is dropped, or its ownership is transferred to another
     /// component by e.g. `handler.handle`.
     headers: func() -> headers;
-
-    /// Get the body associated with the Response, if any.
-    ///
-    /// This body resource is a child: it must be dropped before the parent
-    /// `response` is dropped, or its ownership is transferred to another
-    /// component by e.g. `handler.handle`.
-    body: func() -> option<body>;
 
     /// Takes ownership of the `response` and returns the `headers` and `body`,
     /// if any.


### PR DESCRIPTION
Currently, there are two ways to acquire a handle to the incoming request/response body handle:
1. Call `body` method on the request/response
2. Call `into-parts` static function on the request/response

Assume pseudocode:
```
body := response.body()
stream := body.stream()
stream.read(buf)
drop(stream)
drop(body) // Forgetting this would cause a trap
(_, body) := Response::into_parts(response)
```

There are quite a few issues in the example above.

1. It's very easy to make a mistake and cause a runtime trap, developers must very closely follow the WIT definition and read documentation to avoid a crash at runtime.
2. The host must do a lot of work and state tracking to e.g. ensure underlying body stream state synchronisation. If `body` method can be called at most once, that simplifes the task and potentially, the host could *move* the ownership of the body into the returned resource and *move* it back on `drop` of the body resource. Regardless of the approach and semantics, introducing multiple accessors for the `body` requires increased complexity in the host.

To fix this, simply remove the `body` accessors. This way only a single way to acquire a body resource exists, which eliminates the possibility of misusing the interface by the application developer and simplifies implementation in the host.

This is an alternative solution to #159, will mark that PR as draft.
Closes #159