### PR TITLE
[v0.3] model bodies after `stream<u8, trailers, error-code>`, trap less

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -265,17 +265,26 @@ interface types {
 
     /// Returns the contents of the body, as a stream of bytes.
     ///
-    /// This function may be called multiple times as long as any `stream`s
-    /// returned by previous calls have been dropped first.
-    ///
-    /// On success, this function returns a stream and a future, which will resolve
+    /// This function returns a stream and a future, which will resolve
     /// to an error code if receiving data from stream fails.
-    /// The returned future resolves to success if body is closed.
-    %stream: func() -> result<tuple<stream<u8>, future<result<_, error-code>>>>;
+    /// The returned future resolves to success if data section of the
+    /// body is fully consumed.
+    ///
+    /// The handles returned by this function are considered to be child
+    /// handles. Dropping the resource on which this function is called
+    /// will close the handles with an error context, if they are still open.
+    ///
+    /// This function may be called multiple times.
+    /// If it is called while either a stream or future returned by a previous 
+    /// call to this function is still open, those handles will be closed 
+    /// with an error context.
+    %stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
 
     /// Takes ownership of `body`, and returns an unresolved optional `trailers` result.
     ///
-    /// This function will trap if a `stream` child is still alive.
+    /// Developers are encouraged to close any open handles returned by previous
+    /// calls to `stream`, if any, before calling this function,
+    /// but calling `finish` will close them with an error context.
     finish: static func(this: body) -> future<result<option<trailers>, error-code>>;
   }
 
@@ -356,13 +365,30 @@ interface types {
 
     /// Get the body associated with the Request, if any.
     ///
-    /// This body resource is a child: it must be dropped before the parent
-    /// `request` is dropped, or its ownership is transferred to another
-    /// component by e.g. `handler.handle`.
+    /// This body resource is a child: it must be dropped or consumed before
+    /// the parent `request` is dropped, or its ownership is transferred
+    /// to another component by e.g. `handler.handle`.
+    ///
+    /// Only a single body resource can be active at a time.
+    /// If this function is called before the body resource returned by
+    /// a previous call to this function is dropped, the previously-returned
+    /// body will be transitioned into an "error state" and all operations
+    /// on it will fail.
+    ///
+    /// In case, that a `body.finish` was called on the body returned by a previous
+    /// call to this function, this function returns `none`.
     body: func() -> option<body>;
 
     /// Takes ownership of the `request` and returns the `headers`, `body`
     /// and `request-options`, if any.
+    ///
+    /// The headers returned by this function are considered to be a clone of the headers
+    /// of the request. Changes to the `headers` returned by this function will not be reflected
+    /// in the immutable `headers` resources, that could have been acquired by calls to `headers`
+    /// prior to this function being called.
+    ///
+    /// In case, that a `body.finish` was called on the body returned by a previous
+    /// call to `body`, this function returns body as `none`.
     into-parts: static func(this: request) -> tuple<headers, option<body>, option<request-options>>;
   }
 
@@ -439,13 +465,30 @@ interface types {
 
     /// Get the body associated with the Response, if any.
     ///
-    /// This body resource is a child: it must be dropped before the parent
-    /// `response` is dropped, or its ownership is transferred to another
-    /// component by e.g. `handler.handle`.
+    /// This body resource is a child: it should be dropped or consumed before
+    /// the parent `response` is dropped, or its ownership is transferred
+    /// to another component by e.g. `handler.handle`.
+    ///
+    /// Only a single body resource can be active at a time.
+    /// If this function is called before the body resource returned by
+    /// a previous call to this function is dropped, the previously-returned
+    /// body will be transitioned into an "error state" and all operations
+    /// on it will fail.
+    ///
+    /// In case, that a `body.finish` was called on the body returned by a previous
+    /// call to this function, this function returns `none`.
     body: func() -> option<body>;
 
     /// Takes ownership of the `response` and returns the `headers` and `body`,
     /// if any.
+    ///
+    /// The headers returned by this function are considered to be a clone of the headers
+    /// of the response. Changes to the `headers` returned by this function will not be reflected
+    /// in the immutable `headers` resources, that could have been acquired by calls to `headers`
+    /// prior to this function being called.
+    ///
+    /// In case, that a `body.finish` was called on the body returned by a previous
+    /// call to `body`, this function returns body as `none`.
     into-parts: static func(this: response) -> tuple<headers, option<body>>;
   }
 }

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -265,29 +265,28 @@ interface types {
 
     /// Returns the contents of the body, as a stream of bytes.
     ///
-    /// This function returns a stream and a future, which will resolve
+    /// This method returns a stream and a future, which will resolve
     /// to an error code if receiving data from stream fails.
     /// The returned future resolves to success if data section of the
     /// body is fully consumed.
     ///
-    /// The handles returned by this function are considered to be child
-    /// handles. Dropping the resource on which this function is called
+    /// The handles returned by this method are considered to be child
+    /// handles. Dropping the resource on which this method is called
     /// will close the handles with an error context, if they are still open.
     ///
-    /// This function may be called multiple times.
-    /// If it is called while either a stream or future returned by a previous 
-    /// call to this function is still open, those handles will be closed 
-    /// with an error context. Thus there will always be at most one readable stream
-    /// open for a given body. Each subsequent stream picks up where the last
-    /// stream left off, up until `finish` is called.
-    %stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
+    /// This method may be called multiple times.
+    /// If it is called while either a stream or future returned by a previous
+    /// call to this method is still open, this method will return an error.
+    /// Thus there will always be at most one readable stream open for a given body.
+    /// Each subsequent stream picks up where the last stream left off,
+    /// up until `finish` is called.
+    %stream: func() -> result<tuple<stream<u8>, future<result<_, error-code>>>>;
 
     /// Takes ownership of `body`, and returns an unresolved optional `trailers` result.
     ///
-    /// Developers are encouraged to close any open handles returned by previous
-    /// calls to `stream`, if any, before calling this function,
-    /// but calling `finish` will close them with an error context.
-    finish: static func(this: body) -> future<result<option<trailers>, error-code>>;
+    /// If this function is called while either a stream or future returned by a previous
+    /// call to `body.stream` is still open, this function will return an error.
+    finish: static func(this: body) -> result<future<result<option<trailers>, error-code>>>;
   }
 
   /// Represents an HTTP Request.
@@ -368,14 +367,12 @@ interface types {
     /// to another component by e.g. `handler.handle`.
     ///
     /// Only a single body resource can be active at a time.
-    /// If this function is called before the body resource returned by
-    /// a previous call to this function is dropped, the previously-returned
-    /// body will be transitioned into an "error state" and all operations
-    /// on it will fail.
+    /// If this method is called before the body resource returned by
+    /// a previous call to this method is dropped, error will be returned.
     ///
     /// Once `body.finish` is called on a body returned by this method,
-    /// all subsequent calls to this method will return `none`.
-    body: func() -> option<body>;
+    /// all subsequent calls to this method will return `ok(none)`.
+    body: func() -> result<option<body>>;
 
     /// Takes ownership of the `request` and returns the `headers`, `body`
     /// and `request-options`, if any.
@@ -384,6 +381,8 @@ interface types {
     /// of the request. Changes to the `headers` returned by this function will not be reflected
     /// in the immutable `headers` resources, that could have been acquired by calls to `headers`
     /// prior to this method being called.
+    ///
+    /// If a body child exists when this function is called, an error will be returned.
     ///
     /// Once `body.finish` is called on a body returned by a previous
     /// call to `body` method, this method returns body as `none`.
@@ -464,14 +463,12 @@ interface types {
     /// to another component by e.g. `handler.handle`.
     ///
     /// Only a single body resource can be active at a time.
-    /// If this function is called before the body resource returned by
-    /// a previous call to this function is dropped, the previously-returned
-    /// body will be transitioned into an "error state" and all operations
-    /// on it will fail.
+    /// If this method is called before the body resource returned by
+    /// a previous call to this method is dropped, error will be returned.
     ///
     /// Once `body.finish` is called on a body returned by this method,
-    /// all subsequent calls to this method will return `none`.
-    body: func() -> option<body>;
+    /// all subsequent calls to this method will return `ok(none)`.
+    body: func() -> result<option<body>>;
 
     /// Takes ownership of the `response` and returns the `headers` and `body`,
     /// if any.
@@ -481,8 +478,10 @@ interface types {
     /// in the immutable `headers` resources, that could have been acquired by calls to `headers`
     /// prior to this method being called.
     ///
+    /// If a body child exists when this function is called, an error will be returned.
+    ///
     /// Once `body.finish` is called on a body returned by a previous
     /// call to `body` method, this method returns body as `none`.
-    into-parts: static func(this: response) -> tuple<headers, option<body>>;
+    into-parts: static func(this: response) -> result<tuple<headers, option<body>>>;
   }
 }

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -230,79 +230,35 @@ interface types {
   /// Trailers is an alias for Fields.
   type trailers = fields;
 
-  /// Represents an HTTP Request or Response's Body.
-  ///
-  /// A body has both its contents - a stream of bytes - and a (possibly empty)
-  /// set of trailers, indicating that the full contents of the body have been
-  /// received. This resource represents the contents as a `stream<u8>` and the
-  /// delivery of trailers as a `trailers`, and ensures that the user of this
-  /// interface may only be consuming either the body contents or waiting on
-  /// trailers at any given time.
-  resource body {
-
-    /// Construct a new `body` with the specified stream and `finish` future.
-    ///
-    /// The `finish` future must resolve to a result once `stream` has finished.
-    ///
-    /// This function returns a future, which will resolve to an error code if
-    /// transmitting of the request or response this body is a part of fails.
-    ///
-    /// The returned future resolves to success once request or response this
-    /// body is a part of is fully transmitted.
-    new: static func(
-      %stream: stream<u8>,
-      finish: future<result<option<trailers>, error-code>>,
-    ) -> tuple<body, future<result<_, error-code>>>;
-
-    /// Returns the contents of the body, as a stream of bytes.
-    ///
-    /// This method returns a stream and a future, which will resolve
-    /// to an error code if receiving data from stream fails.
-    /// The returned future resolves to success if data section of the
-    /// body is fully consumed.
-    ///
-    /// The handles returned by this method are considered to be child
-    /// handles. Dropping the resource on which this method is called
-    /// will close the handles with an error context, if they are still open.
-    ///
-    /// This method may be called multiple times.
-    /// This method will return an error if it is called while either:
-    /// - a stream or future returned by a previous call to this method is still open
-    /// - `finish` was called on another instance of this `body` resource
-    /// Thus there will always be at most one readable stream open for a given body.
-    /// Each subsequent stream picks up where the last stream left off,
-    /// up until `finish` is called on any of the instances of this `body` resource
-    %stream: func() -> result<tuple<stream<u8>, future<result<_, error-code>>>>;
-
-    /// Takes ownership of `body`, and returns an unresolved optional `trailers` result.
-    ///
-    /// This function will return an error if it is called while either:
-    /// - a stream or future returned by a previous call to `body.stream` is still open
-    /// - `finish` was already called on another instance of this `body` resource
-    finish: static func(this: body) -> result<future<result<option<trailers>, error-code>>>;
-  }
-
   /// Represents an HTTP Request.
   resource request {
 
     /// Construct a new `request` with a default `method` of `GET`, and
     /// `none` values for `path-with-query`, `scheme`, and `authority`.
     ///
-    /// * `headers` is the HTTP Headers for the Response.
-    /// * `body` is the contents of the body, possibly including trailers.
-    /// * `options` is optional `request-options` to be used if the request is
-    ///   sent over a network connection.
+    /// `headers` is the HTTP Headers for the Request.
+    ///
+    /// `contents` is the body content stream. Once it is closed,
+    /// `trailers` future must resolve to a result.
+    /// If `trailers` resolves to an error, underlying connection
+    /// will be closed immediately.
+    ///
+    /// `options` is optional `request-options` resource to be used
+    /// if the request is sent over a network connection.
     ///
     /// It is possible to construct, or manipulate with the accessor functions
-    /// below, an `request` with an invalid combination of `scheme`
+    /// below, a `request` with an invalid combination of `scheme`
     /// and `authority`, or `headers` which are not permitted to be sent.
     /// It is the obligation of the `handler.handle` implementation
     /// to reject invalid constructions of `request`.
-    constructor(
+    ///
+    /// The returned future resolves to result of transmission of this request.
+    new: static func(
       headers: headers,
-      body: body,
+      contents: stream<u8>,
+      trailers: future<result<option<trailers>, error-code>>,
       options: option<request-options>
-    );
+    ) -> tuple<request, future<result<_, error-code>>>;
 
     /// Get the Method for the Request.
     method: func() -> method;
@@ -352,15 +308,26 @@ interface types {
     /// `delete` operations will fail with `header-error.immutable`.
     headers: func() -> headers;
 
-    /// Get the body associated with the Request, if any.
+    /// Get body of the Request.
     ///
-    /// This body resource is a child: it must be dropped or consumed before
-    /// the parent `request` is dropped, or its ownership is transferred
-    /// to another component by e.g. `handler.handle`.
+    /// Stream returned by this method represents the contents of the body.
+    /// Once the stream is reported as closed, callers should await the returned future
+    /// to determine whether the body was received successfully.
+    /// The future will only resolve after the stream is reported as closed.
     ///
-    /// Once `body.finish` is called on a body returned by this method,
-    /// all subsequent calls to this method will return `none`.
-    body: func() -> option<body>;
+    /// The stream and future returned by this method are children:
+    /// they should be closed or consumed before the parent `response`
+    /// is dropped, or its ownership is transferred to another component
+    /// by e.g. `handler.handle`.
+    ///
+    /// This method may be called multiple times.
+    ///
+    /// This method will return `none` if it is called while either:
+    /// - a stream or future returned by a previous call to this method is still open
+    /// - a stream returned by a previous call to this method has reported itself as closed
+    /// Thus there will always be at most one readable stream open for a given body.
+    /// Each subsequent stream picks up where the last stream left off, up until it is finished.
+    body: func() -> option<tuple<stream<u8>, future<result<option<trailers>, error-code>>>>;
   }
 
   /// Parameters for making an HTTP Request. Each of these parameters is
@@ -409,16 +376,23 @@ interface types {
   /// Represents an HTTP Response.
   resource response {
 
-    /// Construct an `response`, with a default `status-code` of `200`.  If a
-    /// different `status-code` is needed, it must be set via the
+    /// Construct a new `response`, with a default `status-code` of `200`.
+    /// If a different `status-code` is needed, it must be set via the
     /// `set-status-code` method.
     ///
-    /// * `headers` is the HTTP Headers for the Response.
-    /// * `body` is the contents of the body, possibly including trailers.
-    constructor(
+    /// `headers` is the HTTP Headers for the Response.
+    ///
+    /// `contents` is the body content stream. Once it is closed,
+    /// `trailers` future must resolve to a result.
+    /// If `trailers` resolves to an error, underlying connection
+    /// will be closed immediately.
+    ///
+    /// The returned future resolves to result of transmission of this response.
+    new: static func(
       headers: headers,
-      body: body,
-    );
+      contents: stream<u8>,
+      trailers: future<result<option<trailers>, error-code>>,
+    ) -> tuple<response, future<result<_, error-code>>>;
 
     /// Get the HTTP Status Code for the Response.
     status-code: func() -> status-code;
@@ -427,20 +401,31 @@ interface types {
     /// given is not a valid http status code.
     set-status-code: func(status-code: status-code) -> result;
 
-    /// Get the headers associated with the Request.
+    /// Get the headers associated with the Response.
     ///
     /// The returned `headers` resource is immutable: `set`, `append`, and
     /// `delete` operations will fail with `header-error.immutable`.
     headers: func() -> headers;
 
-    /// Get the body associated with the Response, if any.
+    /// Get body of the Response.
     ///
-    /// This body resource is a child: it should be dropped or consumed before
-    /// the parent `response` is dropped, or its ownership is transferred
-    /// to another component by e.g. `handler.handle`.
+    /// Stream returned by this method represents the contents of the body.
+    /// Once the stream is reported as closed, callers should await the returned future
+    /// to determine whether the body was received successfully.
+    /// The future will only resolve after the stream is reported as closed.
     ///
-    /// Once `body.finish` is called on a body returned by this method,
-    /// all subsequent calls to this method will return `none`.
-    body: func() -> option<body>;
+    /// The stream and future returned by this method are children:
+    /// they should be closed or consumed before the parent `response`
+    /// is dropped, or its ownership is transferred to another component
+    /// by e.g. `handler.handle`.
+    ///
+    /// This method may be called multiple times.
+    ///
+    /// This method will return `none` if it is called while either:
+    /// - a stream or future returned by a previous call to this method is still open
+    /// - a stream returned by a previous call to this method has reported itself as closed
+    /// Thus there will always be at most one readable stream open for a given body.
+    /// Each subsequent stream picks up where the last stream left off, up until it is finished.
+    body: func() -> option<tuple<stream<u8>, future<result<option<trailers>, error-code>>>>;
   }
 }

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -240,27 +240,18 @@ interface types {
   /// trailers at any given time.
   resource body {
 
-    /// Construct a new `body` with the specified stream.
+    /// Construct a new `body` with the specified stream and `finish` future.
     ///
-    /// This function returns a future, which will resolve
-    /// to an error code if transmitting stream data fails.
+    /// The `finish` future must resolve to a result once `stream` has finished.
     ///
-    /// The returned future resolves to success once body stream
-    /// is fully transmitted.
+    /// This function returns a future, which will resolve to an error code if
+    /// transmitting of the request or response this body is a part of fails.
+    ///
+    /// The returned future resolves to success once request or response this
+    /// body is a part of is fully transmitted.
     new: static func(
       %stream: stream<u8>,
-    ) -> tuple<body, future<result<_, error-code>>>;
-
-    /// Construct a new `body` with the specified stream and trailers.
-    ///
-    /// This function returns a future, which will resolve
-    /// to an error code if transmitting stream data or trailers fails.
-    ///
-    /// The returned future resolves to success once body stream and trailers
-    /// are fully transmitted.
-    new-with-trailers: static func(
-      %stream: stream<u8>,
-      trailers: future<trailers>
+      finish: future<result<option<trailers>, error-code>>,
     ) -> tuple<body, future<result<_, error-code>>>;
 
     /// Returns the contents of the body, as a stream of bytes.
@@ -298,8 +289,7 @@ interface types {
     /// `none` values for `path-with-query`, `scheme`, and `authority`.
     ///
     /// * `headers` is the HTTP Headers for the Response.
-    /// * `body` is the optional contents of the body, possibly including
-    ///   trailers.
+    /// * `body` is the contents of the body, possibly including trailers.
     /// * `options` is optional `request-options` to be used if the request is
     ///   sent over a network connection.
     ///
@@ -310,7 +300,7 @@ interface types {
     /// to reject invalid constructions of `request`.
     constructor(
       headers: headers,
-      body: option<body>,
+      body: body,
       options: option<request-options>
     );
 
@@ -424,11 +414,10 @@ interface types {
     /// `set-status-code` method.
     ///
     /// * `headers` is the HTTP Headers for the Response.
-    /// * `body` is the optional contents of the body, possibly including
-    ///   trailers.
+    /// * `body` is the contents of the body, possibly including trailers.
     constructor(
       headers: headers,
-      body: option<body>,
+      body: body,
     );
 
     /// Get the HTTP Status Code for the Response.

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -238,7 +238,8 @@ interface types {
     ///
     /// `headers` is the HTTP Headers for the Request.
     ///
-    /// `contents` is the optional body content stream.
+    /// `contents` is the optional body content stream with `none`
+    /// representing a zero-length content stream.
     /// Once it is closed, `trailers` future must resolve to a result.
     /// If `trailers` resolves to an error, underlying connection
     /// will be closed immediately.
@@ -382,7 +383,8 @@ interface types {
     ///
     /// `headers` is the HTTP Headers for the Response.
     ///
-    /// `contents` is the optional body content stream.
+    /// `contents` is the optional body content stream with `none`
+    /// representing a zero-length content stream.
     /// Once it is closed, `trailers` future must resolve to a result.
     /// If `trailers` resolves to an error, underlying connection
     /// will be closed immediately.

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -322,12 +322,12 @@ interface types {
     ///
     /// This method may be called multiple times.
     ///
-    /// This method will return `none` if it is called while either:
+    /// This method will return an error if it is called while either:
     /// - a stream or future returned by a previous call to this method is still open
     /// - a stream returned by a previous call to this method has reported itself as closed
     /// Thus there will always be at most one readable stream open for a given body.
     /// Each subsequent stream picks up where the last stream left off, up until it is finished.
-    body: func() -> option<tuple<stream<u8>, future<result<option<trailers>, error-code>>>>;
+    body: func() -> result<tuple<stream<u8>, future<result<option<trailers>, error-code>>>>;
   }
 
   /// Parameters for making an HTTP Request. Each of these parameters is
@@ -421,11 +421,11 @@ interface types {
     ///
     /// This method may be called multiple times.
     ///
-    /// This method will return `none` if it is called while either:
+    /// This method will return an error if it is called while either:
     /// - a stream or future returned by a previous call to this method is still open
     /// - a stream returned by a previous call to this method has reported itself as closed
     /// Thus there will always be at most one readable stream open for a given body.
     /// Each subsequent stream picks up where the last stream left off, up until it is finished.
-    body: func() -> option<tuple<stream<u8>, future<result<option<trailers>, error-code>>>>;
+    body: func() -> result<tuple<stream<u8>, future<result<option<trailers>, error-code>>>>;
   }
 }

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -277,7 +277,9 @@ interface types {
     /// This function may be called multiple times.
     /// If it is called while either a stream or future returned by a previous 
     /// call to this function is still open, those handles will be closed 
-    /// with an error context.
+    /// with an error context. Thus there will always be at most one readable stream
+    /// open for a given body. Each subsequent stream picks up where the last
+    /// stream left off, up until `finish` is called.
     %stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
 
     /// Takes ownership of `body`, and returns an unresolved optional `trailers` result.
@@ -371,8 +373,8 @@ interface types {
     /// body will be transitioned into an "error state" and all operations
     /// on it will fail.
     ///
-    /// In case, that a `body.finish` was called on the body returned by a previous
-    /// call to this function, this function returns `none`.
+    /// Once `body.finish` is called on a body returned by this method,
+    /// all subsequent calls to this method will return `none`.
     body: func() -> option<body>;
 
     /// Takes ownership of the `request` and returns the `headers`, `body`
@@ -381,10 +383,10 @@ interface types {
     /// The headers returned by this function are considered to be a clone of the headers
     /// of the request. Changes to the `headers` returned by this function will not be reflected
     /// in the immutable `headers` resources, that could have been acquired by calls to `headers`
-    /// prior to this function being called.
+    /// prior to this method being called.
     ///
-    /// In case, that a `body.finish` was called on the body returned by a previous
-    /// call to `body`, this function returns body as `none`.
+    /// Once `body.finish` is called on a body returned by a previous
+    /// call to `body` method, this method returns body as `none`.
     into-parts: static func(this: request) -> tuple<headers, option<body>, option<request-options>>;
   }
 
@@ -467,8 +469,8 @@ interface types {
     /// body will be transitioned into an "error state" and all operations
     /// on it will fail.
     ///
-    /// In case, that a `body.finish` was called on the body returned by a previous
-    /// call to this function, this function returns `none`.
+    /// Once `body.finish` is called on a body returned by this method,
+    /// all subsequent calls to this method will return `none`.
     body: func() -> option<body>;
 
     /// Takes ownership of the `response` and returns the `headers` and `body`,
@@ -477,10 +479,10 @@ interface types {
     /// The headers returned by this function are considered to be a clone of the headers
     /// of the response. Changes to the `headers` returned by this function will not be reflected
     /// in the immutable `headers` resources, that could have been acquired by calls to `headers`
-    /// prior to this function being called.
+    /// prior to this method being called.
     ///
-    /// In case, that a `body.finish` was called on the body returned by a previous
-    /// call to `body`, this function returns body as `none`.
+    /// Once `body.finish` is called on a body returned by a previous
+    /// call to `body` method, this method returns body as `none`.
     into-parts: static func(this: response) -> tuple<headers, option<body>>;
   }
 }

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -407,6 +407,10 @@ interface types {
     /// body stream. An error return value indicates that this timeout is not
     /// supported or that this handle is immutable.
     set-between-bytes-timeout: func(duration: option<duration>) -> result<_, request-options-error>;
+
+    /// Make a deep copy of the `request-options`.
+    /// The resulting `request-options` is mutable.
+    clone: func() -> request-options;
   }
 
   /// This type corresponds to the HTTP standard Status Code.

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -238,8 +238,8 @@ interface types {
     ///
     /// `headers` is the HTTP Headers for the Request.
     ///
-    /// `contents` is the body content stream. Once it is closed,
-    /// `trailers` future must resolve to a result.
+    /// `contents` is the optional body content stream.
+    /// Once it is closed, `trailers` future must resolve to a result.
     /// If `trailers` resolves to an error, underlying connection
     /// will be closed immediately.
     ///
@@ -255,7 +255,7 @@ interface types {
     /// The returned future resolves to result of transmission of this request.
     new: static func(
       headers: headers,
-      contents: stream<u8>,
+      contents: option<stream<u8>>,
       trailers: future<result<option<trailers>, error-code>>,
       options: option<request-options>
     ) -> tuple<request, future<result<_, error-code>>>;
@@ -382,15 +382,15 @@ interface types {
     ///
     /// `headers` is the HTTP Headers for the Response.
     ///
-    /// `contents` is the body content stream. Once it is closed,
-    /// `trailers` future must resolve to a result.
+    /// `contents` is the optional body content stream.
+    /// Once it is closed, `trailers` future must resolve to a result.
     /// If `trailers` resolves to an error, underlying connection
     /// will be closed immediately.
     ///
     /// The returned future resolves to result of transmission of this response.
     new: static func(
       headers: headers,
-      contents: stream<u8>,
+      contents: option<stream<u8>>,
       trailers: future<result<option<trailers>, error-code>>,
     ) -> tuple<response, future<result<_, error-code>>>;
 

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -357,10 +357,6 @@ interface types {
     ///
     /// The returned `headers` resource is immutable: `set`, `append`, and
     /// `delete` operations will fail with `header-error.immutable`.
-    ///
-    /// This headers resource is a child: it must be dropped before the parent
-    /// `request` is dropped, or its ownership is transferred to another
-    /// component by e.g. `handler.handle`.
     headers: func() -> headers;
 
     /// Get the body associated with the Request, if any.
@@ -457,10 +453,6 @@ interface types {
     ///
     /// The returned `headers` resource is immutable: `set`, `append`, and
     /// `delete` operations will fail with `header-error.immutable`.
-    ///
-    /// This headers resource is a child: it must be dropped before the parent
-    /// `response` is dropped, or its ownership is transferred to another
-    /// component by e.g. `handler.handle`.
     headers: func() -> headers;
 
     /// Get the body associated with the Response, if any.

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -275,17 +275,19 @@ interface types {
     /// will close the handles with an error context, if they are still open.
     ///
     /// This method may be called multiple times.
-    /// If it is called while either a stream or future returned by a previous
-    /// call to this method is still open, this method will return an error.
+    /// This method will return an error if it is called while either:
+    /// - a stream or future returned by a previous call to this method is still open
+    /// - `finish` was called on another instance of this `body` resource
     /// Thus there will always be at most one readable stream open for a given body.
     /// Each subsequent stream picks up where the last stream left off,
-    /// up until `finish` is called.
+    /// up until `finish` is called on any of the instances of this `body` resource
     %stream: func() -> result<tuple<stream<u8>, future<result<_, error-code>>>>;
 
     /// Takes ownership of `body`, and returns an unresolved optional `trailers` result.
     ///
-    /// If this function is called while either a stream or future returned by a previous
-    /// call to `body.stream` is still open, this function will return an error.
+    /// This function will return an error if it is called while either:
+    /// - a stream or future returned by a previous call to `body.stream` is still open
+    /// - `finish` was already called on another instance of this `body` resource
     finish: static func(this: body) -> result<future<result<option<trailers>, error-code>>>;
   }
 
@@ -366,27 +368,9 @@ interface types {
     /// the parent `request` is dropped, or its ownership is transferred
     /// to another component by e.g. `handler.handle`.
     ///
-    /// Only a single body resource can be active at a time.
-    /// If this method is called before the body resource returned by
-    /// a previous call to this method is dropped, error will be returned.
-    ///
     /// Once `body.finish` is called on a body returned by this method,
-    /// all subsequent calls to this method will return `ok(none)`.
-    body: func() -> result<option<body>>;
-
-    /// Takes ownership of the `request` and returns the `headers`, `body`
-    /// and `request-options`, if any.
-    ///
-    /// The headers returned by this function are considered to be a clone of the headers
-    /// of the request. Changes to the `headers` returned by this function will not be reflected
-    /// in the immutable `headers` resources, that could have been acquired by calls to `headers`
-    /// prior to this method being called.
-    ///
-    /// If a body child exists when this function is called, an error will be returned.
-    ///
-    /// Once `body.finish` is called on a body returned by a previous
-    /// call to `body` method, this method returns body as `none`.
-    into-parts: static func(this: request) -> tuple<headers, option<body>, option<request-options>>;
+    /// all subsequent calls to this method will return `none`.
+    body: func() -> option<body>;
   }
 
   /// Parameters for making an HTTP Request. Each of these parameters is
@@ -462,26 +446,8 @@ interface types {
     /// the parent `response` is dropped, or its ownership is transferred
     /// to another component by e.g. `handler.handle`.
     ///
-    /// Only a single body resource can be active at a time.
-    /// If this method is called before the body resource returned by
-    /// a previous call to this method is dropped, error will be returned.
-    ///
     /// Once `body.finish` is called on a body returned by this method,
-    /// all subsequent calls to this method will return `ok(none)`.
-    body: func() -> result<option<body>>;
-
-    /// Takes ownership of the `response` and returns the `headers` and `body`,
-    /// if any.
-    ///
-    /// The headers returned by this function are considered to be a clone of the headers
-    /// of the response. Changes to the `headers` returned by this function will not be reflected
-    /// in the immutable `headers` resources, that could have been acquired by calls to `headers`
-    /// prior to this method being called.
-    ///
-    /// If a body child exists when this function is called, an error will be returned.
-    ///
-    /// Once `body.finish` is called on a body returned by a previous
-    /// call to `body` method, this method returns body as `none`.
-    into-parts: static func(this: response) -> result<tuple<headers, option<body>>>;
+    /// all subsequent calls to this method will return `none`.
+    body: func() -> option<body>;
   }
 }


### PR DESCRIPTION
- Make bodies non-optional for request and response constructors
- Take a `future<result<option<trailers>, error-code>>` parameter in request/response constructors (refs https://github.com/WebAssembly/component-model/issues/474#issuecomment-2736430031)
- Report any transmit errors occurring in the future returned by request/response constructor
- Allow `headers` resources acquired by calling `request.headers` or `response.headers` to persist *after* respective `into-parts` is called, referencing the immutable headers of the original request/response. This implies that the `headers` acquired this way are not, if fact, children of the original request/response they originated from and the original request/response can be freely dropped and/or moved even before they are dropped.
- Do not trap if guest attempts to acquire multiple handles to the body stream - handle that using type system
- Model bodies after future `stream<u8, trailers, error-code>`
- Remove `into-parts`
- Add `request-options#clone`

Closes https://github.com/WebAssembly/wasi-http/pull/156
Closes https://github.com/WebAssembly/wasi-http/pull/161
Closes #164 
Closes #163 
Closes #165 