### PR TITLE
Add `get-*` prefix to getters

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -262,14 +262,14 @@ interface types {
     ) -> tuple<request, future<result<_, error-code>>>;
 
     /// Get the Method for the Request.
-    method: func() -> method;
+    get-method: func() -> method;
     /// Set the Method for the Request. Fails if the string present in a
     /// `method.other` argument is not a syntactically valid method.
     set-method: func(method: method) -> result;
 
     /// Get the combination of the HTTP Path and Query for the Request.  When
     /// `none`, this represents an empty Path and empty Query.
-    path-with-query: func() -> option<string>;
+    get-path-with-query: func() -> option<string>;
     /// Set the combination of the HTTP Path and Query for the Request.  When
     /// `none`, this represents an empty Path and empty Query. Fails is the
     /// string given is not a syntactically valid path and query uri component.
@@ -277,7 +277,7 @@ interface types {
 
     /// Get the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
-    scheme: func() -> option<scheme>;
+    get-scheme: func() -> option<scheme>;
     /// Set the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme. Fails if the
     /// string given is not a syntactically valid uri scheme.
@@ -286,7 +286,7 @@ interface types {
     /// Get the authority of the Request's target URI. A value of `none` may be used
     /// with Related Schemes which do not require an authority. The HTTP and
     /// HTTPS schemes always require an authority.
-    authority: func() -> option<string>;
+    get-authority: func() -> option<string>;
     /// Set the authority of the Request's target URI. A value of `none` may be used
     /// with Related Schemes which do not require an authority. The HTTP and
     /// HTTPS schemes always require an authority. Fails if the string given is
@@ -342,7 +342,7 @@ interface types {
     constructor();
 
     /// The timeout for the initial connect to the HTTP Server.
-    connect-timeout: func() -> option<duration>;
+    get-connect-timeout: func() -> option<duration>;
 
     /// Set the timeout for the initial connect to the HTTP Server. An error
     /// return value indicates that this timeout is not supported or that this
@@ -350,7 +350,7 @@ interface types {
     set-connect-timeout: func(duration: option<duration>) -> result<_, request-options-error>;
 
     /// The timeout for receiving the first byte of the Response body.
-    first-byte-timeout: func() -> option<duration>;
+    get-first-byte-timeout: func() -> option<duration>;
 
     /// Set the timeout for receiving the first byte of the Response body. An
     /// error return value indicates that this timeout is not supported or that
@@ -359,7 +359,7 @@ interface types {
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
-    between-bytes-timeout: func() -> option<duration>;
+    get-between-bytes-timeout: func() -> option<duration>;
 
     /// Set the timeout for receiving subsequent chunks of bytes in the Response
     /// body stream. An error return value indicates that this timeout is not
@@ -397,7 +397,7 @@ interface types {
     ) -> tuple<response, future<result<_, error-code>>>;
 
     /// Get the HTTP Status Code for the Response.
-    status-code: func() -> status-code;
+    get-status-code: func() -> status-code;
 
     /// Set the HTTP Status Code for the Response. Fails if the status-code
     /// given is not a valid http status code.


### PR DESCRIPTION
As proposed in the [last WASI meeting](https://docs.google.com/presentation/d/1on-QuMkOQ-2GCFcJG0DulxKIEDN4KrxveD--gFIzWyQ/edit?usp=sharing), this PR prefixes the following property-like methods with `get-`:
- `request.method`
- `request.path-with-query`
- `request.scheme`
- `request.authority`
- `request-options.connect-timeout`
- `request-options.first-byte-timeout`
- `request-options.between-bytes-timeout`
- `response.status-code`

I don't foresee any trouble with emitting these as properties in source languages.

---

However, the interface also contains:
- `fields.entries`
- `request.options`
- `request.headers` & `response.headers`
- `request.body` & `response.body`

I haven't prefixed these yet. Their names are standalone nouns so my OOP brain wants these to follow the property conventions too. E.g., I'd expect a Java binding generator to produce `getEntries`, `getOptions`, `getHeaders` & `getBody`.
But using the property convention/syntax generally comes with the implicit assumption that accessing it is cheap, idempotent and/or side-effect free. That's not the case here. For example, the following snippet would normally be idiomatic JavaScript code:

```cs
var host = request.headers.entries["Host"];
var forwardedFor = request.headers.entries["X-Forwarded-For"];
```

but actually, this creates two new owned `fields` handles that are never disposed of. And all the `entries` are copied over fully twice as well. So this seemingly fine code is actually inefficient & leaking resources.

I'm ignoring the existence of the `fields.get` method to get the point across :)

---

Ideas on this are welcome. Concretely I want to know how to proceed:
- Should we prefix those methods with `get-*` anyway and leave it for future selves to figure out?
- Should we assume these methods will never become properties and continue this PR as-is?

@lukewagner Thoughts?