### PR TITLE
p3: rework `consume-body`

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -316,20 +316,12 @@ interface types {
     /// future to determine whether the body was received successfully.
     /// The future will only resolve after the stream is reported as closed.
     ///
-    /// The stream and future returned by this method are children:
-    /// they should be closed or consumed before the parent `response`
-    /// is dropped, or its ownership is transferred to another component
-    /// by e.g. `handler.handle`.
+    /// This function takes a `res` future as a parameter, which can be used to
+    /// communicate an error in handling of the request.
     ///
-    /// This method may be called multiple times.
-    ///
-    /// This method will return an error if it is called while either:
-    /// - a stream or future returned by a previous call to this method is still open
-    /// - a stream returned by a previous call to this method has reported itself as closed
-    /// Thus there will always be at most one readable stream open for a given body.
-    /// Each subsequent stream picks up where the previous one left off,
-    /// continuing until the entire body has been consumed.
-    consume-body: func() -> result<tuple<stream<u8>, future<result<option<trailers>, error-code>>>>;
+    /// Note that function will move the `request`, but references to headers or
+    /// request options acquired from it previously will remain valid.
+    consume-body: static func(this: request, res: future<result<_, error-code>>) -> tuple<stream<u8>, future<result<option<trailers>, error-code>>>;
   }
 
   /// Parameters for making an HTTP Request. Each of these parameters is
@@ -417,19 +409,11 @@ interface types {
     /// future to determine whether the body was received successfully.
     /// The future will only resolve after the stream is reported as closed.
     ///
-    /// The stream and future returned by this method are children:
-    /// they should be closed or consumed before the parent `response`
-    /// is dropped, or its ownership is transferred to another component
-    /// by e.g. `handler.handle`.
+    /// This function takes a `res` future as a parameter, which can be used to
+    /// communicate an error in handling of the response.
     ///
-    /// This method may be called multiple times.
-    ///
-    /// This method will return an error if it is called while either:
-    /// - a stream or future returned by a previous call to this method is still open
-    /// - a stream returned by a previous call to this method has reported itself as closed
-    /// Thus there will always be at most one readable stream open for a given body.
-    /// Each subsequent stream picks up where the previous one left off,
-    /// continuing until the entire body has been consumed.
-    consume-body: func() -> result<tuple<stream<u8>, future<result<option<trailers>, error-code>>>>;
+    /// Note that function will move the `response`, but references to headers
+    /// acquired from it previously will remain valid.
+    consume-body: static func(this: response, res: future<result<_, error-code>>) -> tuple<stream<u8>, future<result<option<trailers>, error-code>>>;
   }
 }


### PR DESCRIPTION
This PR addresses two gaps in current `wasi:http`:
- `{request,response}::new` return a `future<result<_, error-code>>`, but in case that `consume-body` is called on a request/response originating from this constructor, there is no way for the component to actually communicate a result on that future.
- `consume-body` is a method on request/response, but it can only be called once. That introduces complexity for the implementers and a potential hazard for the users, for example:
```
export wasi:http/handler#handle(req)
   res = wasi:http/handler#handle(req)
   res.consume_body()
   return res
```
Whether returning a response, body of which has been consumed, is valid or not is not obvious.

To address these issues:
- Take `future<result<_, error-code>>` as parameter in `consume-body` (see #176 for more details)
- Make `consume-body` a *static* function moving the request/response it's called on.

A note on partial body read use case:
Some implementations may want to read *some* data from the body, but pass along the rest.
Such use cases are enabled with a pattern as follows:
```
export wasi:http/handler#handle(req)
   (tx, rx) = future()
   (body, trailers) = wasi:http/types.request#consume_body(req, rx)
   stream.read(body, 8) // read 8 bytes from body stream
   headers = wasi:http/types.fields()
   (res, result) = wasi:http/types.response#new(headers, Some(body), trailers, None)
   spawn(async {
      tx.send(result.await)
   })
   return res
```

Closes #176 
Wasmtime implementation: https://github.com/bytecodealliance/wasmtime/pull/11653