### PR TITLE
use new clocks/types.{duration} instead of clocks/monotonic

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -1,7 +1,7 @@
 /// This interface defines all of the types and methods for implementing HTTP
 /// Requests and Responses, as well as their headers, trailers, and bodies.
 interface types {
-  use wasi:clocks/monotonic-clock@0.3.0-rc-2025-09-16.{duration};
+  use wasi:clocks/types@0.3.0-rc-2025-09-16.{duration};
 
   /// This type corresponds to HTTP standard Methods.
   variant method {


### PR DESCRIPTION
https://github.com/WebAssembly/wasi-clocks/pull/98 split the `duration` type out into its own file, which can be imported directly instead of needing to reach into the `monotonic` package. This is [already pulled in to the deps](https://github.com/WebAssembly/wasi-http/blob/ce36dac529d5def9e5191dd624e928eb12325111/wit-0.3.0-draft/deps/clocks/types.wit) so should be usable here.